### PR TITLE
Implementing `WaypointsInfillRepair` and `ConstraintViolationRepair` with an orchestrator (`ChainedRepair`)

### DIFF
--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -279,7 +279,7 @@ class Genetic(RoutingAlg):
                 markerfacecolor="gold",
                 markeredgecolor="black", )
 
-            for iroute in range(0, self.pop_size):
+            for iroute in range(0, last_pop.shape[0]):
                 if iroute == 0:
                     ax.plot(
                         last_pop[iroute, 0][:, 1],

--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -273,36 +273,33 @@ class Genetic(RoutingAlg):
 
             last_pop = history[igen].pop.get('X')
 
+            marker_kw = dict(
+                marker="o",
+                markersize=3,
+                markerfacecolor="gold",
+                markeredgecolor="black", )
+
             for iroute in range(0, self.pop_size):
                 if iroute == 0:
                     ax.plot(
                         last_pop[iroute, 0][:, 1],
                         last_pop[iroute, 0][:, 0],
+                        **(marker_kw if igen != self.n_generations - 1 else {}),
                         color="firebrick",
-                        marker="o",
-                        markersize=4,
-                        markerfacecolor="gold",
-                        markeredgecolor="black",
                         label=f"full population [{last_pop.shape[0]}]", )
 
                 else:
                     ax.plot(
                         last_pop[iroute, 0][:, 1],
                         last_pop[iroute, 0][:, 0],
-                        marker="o",
-                        markersize=4,
-                        markerfacecolor="gold",
-                        markeredgecolor="black",
+                        **(marker_kw if igen != self.n_generations - 1 else {}),
                         color="firebrick", )
 
             if igen == (self.n_generations - 1):
                 ax.plot(
                     best_route[:, 1],
                     best_route[:, 0],
-                    marker="o",
-                    markersize=4,
-                    markerfacecolor="gold",
-                    markeredgecolor="black",
+                    **marker_kw,
                     color="blue",
                     label="best route", )
 

--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -74,7 +74,8 @@ class Genetic(RoutingAlg):
 
         mutation = MutationFactory.get_mutation(self.config)
 
-        repair = RepairFactory.get_repair()
+        repair = RepairFactory.get_repair(
+            self.config, constraints_list)
 
         duplicates = utils.RouteDuplicateElimination()
 

--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -42,6 +42,9 @@ class Genetic(RoutingAlg):
         # self.figure_path = graphics.get_figure_path()
         self.figure_path = os.path.join(config.ROUTE_PATH, "figs")
 
+        if not os.path.exists(self.figure_path):
+            os.makedirs(self.figure_path)
+
         self.default_map: Map = config.DEFAULT_MAP
 
         self.n_generations = config.GENETIC_NUMBER_GENERATIONS
@@ -85,7 +88,7 @@ class Genetic(RoutingAlg):
             res=res_minimize,
             problem=problem,)
 
-        return res_terminate
+        return res_terminate, 0
 
     def optimize(
         self,

--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -39,11 +39,10 @@ class Genetic(RoutingAlg):
         self.config = config
 
         # running
-        # self.figure_path = graphics.get_figure_path()
-        self.figure_path = os.path.join(config.ROUTE_PATH, "figs")
+        self.figure_path = graphics.get_figure_path()
 
-        if not os.path.exists(self.figure_path):
-            os.makedirs(self.figure_path)
+        if self.figure_path is not None:
+            os.makedirs(self.figure_path, exist_ok=True)
 
         self.default_map: Map = config.DEFAULT_MAP
 

--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -88,7 +88,7 @@ class Genetic(RoutingAlg):
             res=res_minimize,
             problem=problem,)
 
-        return res_terminate, 0
+        return res_terminate, 9
 
     def optimize(
         self,

--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -279,18 +279,30 @@ class Genetic(RoutingAlg):
                         last_pop[iroute, 0][:, 1],
                         last_pop[iroute, 0][:, 0],
                         color="firebrick",
+                        marker="o",
+                        markersize=4,
+                        markerfacecolor="gold",
+                        markeredgecolor="black",
                         label=f"full population [{last_pop.shape[0]}]", )
 
                 else:
                     ax.plot(
                         last_pop[iroute, 0][:, 1],
                         last_pop[iroute, 0][:, 0],
+                        marker="o",
+                        markersize=4,
+                        markerfacecolor="gold",
+                        markeredgecolor="black",
                         color="firebrick", )
 
             if igen == (self.n_generations - 1):
                 ax.plot(
                     best_route[:, 1],
                     best_route[:, 0],
+                    marker="o",
+                    markersize=4,
+                    markerfacecolor="gold",
+                    markeredgecolor="black",
                     color="blue",
                     label="best route", )
 

--- a/WeatherRoutingTool/algorithms/genetic/configs/config.isofuel_multiple_routes.json
+++ b/WeatherRoutingTool/algorithms/genetic/configs/config.isofuel_multiple_routes.json
@@ -1,0 +1,50 @@
+{
+  "DEFAULT_ROUTE": [37.50567, 12.304575, 33.82683, 34.31085333],
+  "DEPARTURE_TIME": "2023-08-19T10:32Z",
+  "DEFAULT_MAP": [30, -6, 47, 42],
+
+  "BOAT_DRAUGHT_AFT": 10,
+  "BOAT_DRAUGHT_FORE": 10,
+  "CONSTRAINTS_LIST": [
+    "land_crossing_global_land_mask",
+    "water_depth",
+    "via_waypoints",
+    "on_map"],
+
+  "TIME_FORECAST": 90,
+  "ROUTING_STEPS": 60,
+  "DELTA_TIME_FORECAST": 3,
+  "DELTA_FUEL": 10000,
+
+  "DATA_MODE": "from_file",
+  "COURSES_FILE": "./runtime/data/data-02/courses_route.nc",
+  "DEPTH_DATA": "./runtime/data/data-02/depth_data.nc",
+  "WEATHER_DATA": "./runtime/data/data-02/weather_data.nc",
+  "ROUTE_PATH": "./runtime/workdir-isofuel-many/",
+
+  "ALGORITHM_TYPE":"speedy_isobased",
+  "ISOCHRONE_NUMBER_OF_ROUTES": 20,
+  "ISOCHRONE_PRUNE_GROUPS": "multiple_routes",
+  "ISOCHRONE_PRUNE_SEGMENTS": 200,
+
+  "ROUTER_HDGS_SEGMENTS": 30,
+  "ROUTER_HDGS_INCREMENTS_DEG": 6,
+  "ISOCHRONE_PRUNE_SECTOR_DEG_HALF": 91,
+  "ISOCHRONE_PRUNE_SEGMENTS": 20,
+
+  "ISOCHRONE_MINIMISATION_CRITERION": "squareddist_over_disttodest",
+
+  "GENETIC_NUMBER_GENERATIONS": 20,
+  "GENETIC_NUMBER_OFFSPRINGS": 2,
+  "GENETIC_POPULATION_SIZE": 20,
+  "GENETIC_POPULATION_TYPE": "grid_based",
+
+  "BOAT_TYPE": "speedy_isobased",
+  "BOAT_BREADTH": 32,
+  "BOAT_FUEL_RATE": 167,
+  "BOAT_HBR": 30,
+  "BOAT_LENGTH": 180,
+  "BOAT_SMCR_POWER" : 6502,
+  "BOAT_SMCR_SPEED" : 7,
+  "BOAT_SPEED": 600
+}

--- a/WeatherRoutingTool/algorithms/genetic/configs/config.isofuel_single_route.json
+++ b/WeatherRoutingTool/algorithms/genetic/configs/config.isofuel_single_route.json
@@ -1,0 +1,47 @@
+{
+  "ALGORITHM_TYPE": "speedy_isobased",
+
+  "//": "boat",
+  "BOAT_TYPE": "speedy_isobased",
+  "BOAT_BREADTH": 32,
+  "BOAT_FUEL_RATE": 167,
+  "BOAT_HBR": 30,
+  "BOAT_LENGTH": 180,
+  "BOAT_SMCR_POWER" : 6502,
+  "BOAT_SMCR_SPEED" : 1000,
+  "BOAT_SPEED": 600,
+  "BOAT_DRAUGHT_AFT": 10,
+  "BOAT_DRAUGHT_FORE": 10,
+
+  "//": "route",
+  "DEFAULT_ROUTE": [37.50567, 12.304575, 33.82683, 34.31085333],
+  "DEPARTURE_TIME": "2023-08-19T10:32Z",
+  "DEFAULT_MAP": [30, -6, 47, 42],
+  "CONSTRAINTS_LIST": [
+    "land_crossing_global_land_mask",
+    "water_depth"],
+
+  "//": "data",
+  "DATA_MODE": "from_file",
+
+  "COURSES_FILE": "./runtime/data/data-02/courses_route.nc",
+  "DEPTH_DATA": "./runtime/data/data-02/depth_data.nc",
+  "WEATHER_DATA": "./runtime/data/data-02/weather_data.nc",
+  "ROUTE_PATH": "./runtime/workdir-isofuel-many/",
+
+  "TIME_FORECAST": 90,
+  "DELTA_TIME_FORECAST": 3,
+
+  "//": "isofuel",
+  "DELTA_FUEL": 10000,
+  "ROUTER_HDGS_SEGMENTS": 30,
+  "ROUTER_HDGS_INCREMENTS_DEG": 6,
+  "ISOCHRONE_PRUNE_SECTOR_DEG_HALF": 91,
+  "ISOCHRONE_PRUNE_SEGMENTS": 4,
+  "ISOCHRONE_PRUNE_GROUPS": "branch",
+  "ISOCHRONE_MAX_ROUTING_STEPS": 500,
+
+  "ISOCHRONE_PRUNE_SYMMETRY_AXIS": "headings_based",
+  "ISOCHRONE_MINIMISATION_CRITERION": "squareddist_over_disttodest",
+  "ISOCHRONE_NUMBER_OF_ROUTES": 1
+}

--- a/WeatherRoutingTool/algorithms/genetic/crossover.py
+++ b/WeatherRoutingTool/algorithms/genetic/crossover.py
@@ -96,7 +96,7 @@ class SinglePointCrossover(OffspringRejectionCrossover):
 
         # variables
         self.config = config
-        self.patch_type = "isofuel"
+        self.patch_type = "gcr"
 
     def crossover(self, p1, p2):
         # setup patching
@@ -105,9 +105,7 @@ class SinglePointCrossover(OffspringRejectionCrossover):
                 patchfn = patcher.IsofuelPatcher.for_single_route(
                     default_map=self.config.DEFAULT_MAP, )
             case "gcr":
-                patchfn = patcher.GreatCircleRoutePatcher(
-                    config=self.config,
-                    dist=1e4, )
+                patchfn = patcher.GreatCircleRoutePatcher(dist=1e5)
             case _:
                 raise ValueError("Invalid patcher type")
 
@@ -135,7 +133,7 @@ class TwoPointCrossover(OffspringRejectionCrossover):
 
         # variables
         self.config = config
-        self.patch_type = "isofuel"
+        self.patch_type = "gcr"
 
     def crossover(self, p1, p2):
         match self.patch_type:
@@ -143,9 +141,7 @@ class TwoPointCrossover(OffspringRejectionCrossover):
                 patchfn = patcher.IsofuelPatcher.for_single_route(
                     default_map=self.config.DEFAULT_MAP, )
             case "gcr":
-                patchfn = patcher.GreatCircleRoutePatcher(
-                    config=self.config,
-                    dist=1e4, )
+                patchfn = patcher.GreatCircleRoutePatcher(dist=1e5)
             case _:
                 raise ValueError("Invalid patcher type")
 

--- a/WeatherRoutingTool/algorithms/genetic/mutation.py
+++ b/WeatherRoutingTool/algorithms/genetic/mutation.py
@@ -49,10 +49,10 @@ class RandomWalkMutation(Mutation):
         self.n_updates = n_updates
 
     def random_walk(
-            self,
-            point,
-            dist = int(1e4),
-            bearing: int = 45
+        self,
+        point,
+        dist: int = int(1e4),
+        bearing: int = 45
     ) -> tuple[float, float]:
         """Randomly pick an N4 neighbour of a waypoint"""
 

--- a/WeatherRoutingTool/algorithms/genetic/mutation.py
+++ b/WeatherRoutingTool/algorithms/genetic/mutation.py
@@ -1,18 +1,83 @@
 from pymoo.core.mutation import Mutation
 
+import numpy as np
+
+from copy import deepcopy
 import logging
+import math
 
 from WeatherRoutingTool.config import Config
 
 logger = logging.getLogger("WRT.genetic.mutation")
 
 
-class NoMutation(Mutation):
+# base class
+# ----------
+class MutationBase(Mutation):
+    """Base Mutation Class
+
+    Kept for consistency with how crossover is implemented and to provide
+    super-class level orchestration of Mutation implementations.
+    """
+
     def _do(self, problem, X, **kw):
+        return self.mutate(problem, X, **kw)
+
+    def mutate(self, problem, X, **kw):
         return X
 
 
+# mutation variants
+# ----------
+class NoMutation(MutationBase):
+    def mutate(self, problem, X, **kw):
+        return super().__init__()
+
+
+class RouteBlendMutation(MutationBase):
+    @staticmethod
+    def bezier_curve(control_points, n_points=100):
+        """Generate a Bezier curve given control points.
+
+        :param control_points: List of (x, y) control points
+        :type control_points: np.ndarray
+        :param n_points: Number of points on the curve
+        :type n_points: int
+        :return: Array of shape (n_points, 2) with curve coordinates
+        :rtype: np.ndarray
+        """
+        control_points = np.array(control_points)
+        n = len(control_points) - 1  # degree
+        t = np.linspace(0, 1, n_points)
+        curve = np.zeros((n_points, 2))
+
+        for i in range(n + 1):
+            bernstein = math.comb(n, i) * (t**i) * ((1 - t) ** (n - i))
+            curve += np.outer(bernstein, control_points[i])
+
+        return curve
+
+    def mutate(self, problem, X, **kw):
+        for i, (rt,) in enumerate(X):
+            for _ in range(3):
+                p1 = np.random.randint(0, rt.shape[0])
+                if rt.shape[0] - p1 <= 3:  # retry
+                    continue
+
+                p2 = p1 + np.random.randint(3, min(10, rt.shape[0] - p1))
+                break
+            else:
+                continue
+
+            n_points = (p2 - p1) * 2
+
+            X[i, 0] = np.concatenate(
+                [rt[:p1], self.bezier_curve(rt[p1:p2], n_points), rt[p2:]], axis=0)
+        return X
+
+
+# factory
 class MutationFactory:
     @staticmethod
     def get_mutation(config: Config) -> Mutation:
-        return NoMutation()
+        return RouteBlendMutation()

--- a/WeatherRoutingTool/algorithms/genetic/patcher.py
+++ b/WeatherRoutingTool/algorithms/genetic/patcher.py
@@ -24,9 +24,6 @@ from WeatherRoutingTool.constraints.constraints import ConstraintsListFactory, W
 # base class
 # ----------
 class Patcher:
-    def __init__(self, config: Config):
-        self.config = config
-
     def patch(self, src, dst):
         pass
 
@@ -34,8 +31,8 @@ class Patcher:
 # patcher variants
 # ----------
 class GreatCircleRoutePatcher(Patcher):
-    def __init__(self, config, dist: float = 100_000.0):
-        super().__init__(config)
+    def __init__(self, dist: float = 100_000.0):
+        super().__init__()
 
         # variables
         self.dist = dist
@@ -62,7 +59,7 @@ class GreatCircleRoutePatcher(Patcher):
             s = min(self.dist * i, line.s13)
             g = line.Position(s, Geodesic.STANDARD | Geodesic.LONG_UNROLL)
             route.append((g['lat2'], g['lon2']))
-        return [src, *route[1:-1], dst]
+        return np.array([src, *route[1:-1], dst])
 
 
 class IsofuelPatcher(Patcher):
@@ -131,10 +128,11 @@ class IsofuelPatcher(Patcher):
         return wt, boat, water_depth, constraints_list
 
     def __init__(self, config: Config, n_routes: str = "single"):
-        super().__init__(config=config)
+        super().__init__()
 
         # variables
         self.n_routes = n_routes
+        self.config = config
 
         # setup components
         wt, boat, water_depth, constraints_list = self._setup_components(self.config)

--- a/WeatherRoutingTool/algorithms/genetic/patcher.py
+++ b/WeatherRoutingTool/algorithms/genetic/patcher.py
@@ -21,37 +21,51 @@ from WeatherRoutingTool.utils.maps import Map
 from WeatherRoutingTool.constraints.constraints import ConstraintsListFactory, WaterDepth
 
 
-@functools.cache
-def great_circle_route(
-        src: tuple[float, float],
-        dst: tuple[float, float],
-        distance=100_000.0
-) -> list[tuple[float, float]]:
-    """Generate equi-distant waypoints across the Great Circle Route from src to
-    dst
+# base class
+# ----------
+class Patcher:
+    def __init__(self, config: Config):
+        self.config = config
 
-    :param src: Source waypoint as (lat, lon) pair
-    :type src: tuple[float, float]
-    :param dst: Destination waypoint as (lat, lon) pair
-    :type dst: tuple[float, float]
-    :param distance: Distance between waypoints generated
-    :type distance: float
-    :return: List of waypoints along the great circle (lat, lon)
-    :rtype: list[tuple[float, float]]
-    """
-
-    geod: Geodesic = Geodesic.WGS84
-    line = geod.InverseLine(*src, *dst)
-    n = int(math.ceil(line.s13 / distance))
-    route = []
-    for i in range(n + 1):
-        s = min(distance * i, line.s13)
-        g = line.Position(s, Geodesic.STANDARD | Geodesic.LONG_UNROLL)
-        route.append((g['lat2'], g['lon2']))
-    return [src, *route[1:-1], dst]
+    def patch(self, src, dst):
+        pass
 
 
-class IsofuelPatcher:
+# patcher variants
+# ----------
+class GreatCircleRoutePatcher(Patcher):
+    def __init__(self, config, dist: float = 100_000.0):
+        super().__init__(config)
+
+        # variables
+        self.dist = dist
+
+    def patch(self, src, dst, departure_time: datetime = None):
+        """Generate equi-distant waypoints across the Great Circle Route from src to
+        dst
+
+        :param src: Source waypoint as (lat, lon) pair
+        :type src: tuple[float, float]
+        :param dst: Destination waypoint as (lat, lon) pair
+        :type dst: tuple[float, float]
+        :param distance: Distance between waypoints generated
+        :type distance: float
+        :return: List of waypoints along the great circle (lat, lon)
+        :rtype: list[tuple[float, float]]
+        """
+
+        geod: Geodesic = Geodesic.WGS84
+        line = geod.InverseLine(*src, *dst)
+        n = int(math.ceil(line.s13 / self.dist))
+        route = []
+        for i in range(n + 1):
+            s = min(self.dist * i, line.s13)
+            g = line.Position(s, Geodesic.STANDARD | Geodesic.LONG_UNROLL)
+            route.append((g['lat2'], g['lon2']))
+        return [src, *route[1:-1], dst]
+
+
+class IsofuelPatcher(Patcher):
     """Use the IsoFuel algorithm for route(s) generation
 
     Intuition behind having this as a class:
@@ -117,7 +131,9 @@ class IsofuelPatcher:
         return wt, boat, water_depth, constraints_list
 
     def __init__(self, config: Config, n_routes: str = "single"):
-        self.config = config
+        super().__init__(config=config)
+
+        # variables
         self.n_routes = n_routes
 
         # setup components
@@ -128,7 +144,7 @@ class IsofuelPatcher:
         self.water_depth: WaterDepth = water_depth
         self.constraints_list: ConstraintsList = constraints_list
 
-    def generate(self, src, dst, departure_time: datetime) -> Union[np.ndarray, list[np.ndarray]]:
+    def patch(self, src, dst, departure_time: datetime = None):
         cfg = self.config.model_copy(update={
             "DEFAULT_ROUTE": [*src, *dst],
             "DEPARTURE_TIME": departure_time

--- a/WeatherRoutingTool/algorithms/genetic/patcher.py
+++ b/WeatherRoutingTool/algorithms/genetic/patcher.py
@@ -173,7 +173,7 @@ class IsofuelPatcher:
     @classmethod
     def for_single_route(cls, default_map, **kw):
         cfg = Config.assign_config(
-            path=Path(os.path.dirname(__file__)) / "configs" / "config.isofuel_population.json")
+            path=Path(os.path.dirname(__file__)) / "configs" / "config.isofuel_single_route.json")
 
         cfg.DEFAULT_MAP = default_map
 

--- a/WeatherRoutingTool/algorithms/genetic/patcher.py
+++ b/WeatherRoutingTool/algorithms/genetic/patcher.py
@@ -1,0 +1,174 @@
+from typing import Union
+
+from geographiclib.geodesic import Geodesic
+import numpy as np
+
+from pathlib import Path
+from datetime import datetime
+import functools
+import math
+import os
+
+from WeatherRoutingTool.weather import WeatherCond
+from WeatherRoutingTool.ship.ship import Boat
+from WeatherRoutingTool.constraints.constraints import ConstraintsList
+
+
+from WeatherRoutingTool.algorithms.isofuel import IsoFuel
+from WeatherRoutingTool.ship.ship_factory import ShipFactory
+from WeatherRoutingTool.weather_factory import WeatherFactory
+from WeatherRoutingTool.config import Config
+from WeatherRoutingTool.ship.ship_factory import ShipFactory
+from WeatherRoutingTool.utils.maps import Map
+from WeatherRoutingTool.weather_factory import WeatherFactory
+from WeatherRoutingTool.constraints.constraints import ConstraintsListFactory, WaterDepth
+
+
+@functools.cache
+def great_circle_route(
+        src: tuple[float, float],
+        dst: tuple[float, float],
+        distance=100_000.0
+) -> list[tuple[float, float]]:
+    """Generate equi-distant waypoints across the Great Circle Route from src to
+    dst
+
+    :param src: Source waypoint as (lat, lon) pair
+    :type src: tuple[float, float]
+    :param dst: Destination waypoint as (lat, lon) pair
+    :type dst: tuple[float, float]
+    :param distance: Distance between waypoints generated
+    :type distance: float
+    :return: List of waypoints along the great circle (lat, lon)
+    :rtype: list[tuple[float, float]]
+    """
+
+    geod: Geodesic = Geodesic.WGS84
+    line = geod.InverseLine(*src, *dst)
+    n = int(math.ceil(line.s13 / distance))
+    route = []
+    for i in range(n + 1):
+        s = min(distance * i, line.s13)
+        g = line.Position(s, Geodesic.STANDARD | Geodesic.LONG_UNROLL)
+        route.append((g['lat2'], g['lon2']))
+    return [src, *route[1:-1], dst]
+
+
+class IsofuelPatcher:
+    """Use the IsoFuel algorithm for route(s) generation
+
+    Intuition behind having this as a class:
+    1. The Isofuel path finding component can be quite expensive during the preparation stage (defining map, loading data, etc.).
+        Having setup and execution as separate components could help speed things up.
+    """
+
+    def _setup_components(self, config):
+        """
+        Execute route optimization based on the user-defined configuration.
+        After a successful run the final route is saved into the configured folder.
+
+        :param config: validated configuration
+        :type config: WeatherRoutingTool.config.Config
+        :return: None
+        """
+        # prof = cProfile.Profile()
+        # prof.enable()
+
+        # *******************************************
+        # basic settings
+        windfile = config.WEATHER_DATA
+        depthfile = config.DEPTH_DATA
+        routepath = config.ROUTE_PATH
+        time_resolution = config.DELTA_TIME_FORECAST
+        time_forecast = config.TIME_FORECAST
+        lat1, lon1, lat2, lon2 = config.DEFAULT_MAP
+        departure_time = config.DEPARTURE_TIME
+        default_map = Map(lat1, lon1, lat2, lon2)
+
+        # *******************************************
+        # initialise weather
+        wt = WeatherFactory.get_weather(config._DATA_MODE_WEATHER, windfile, departure_time, time_forecast, time_resolution,
+                                        default_map)
+
+        # *******************************************
+        # initialise boat
+        boat = ShipFactory.get_ship(config)
+        # boat = ConstantFuelBoat(init_mode="from_dict", config_dict=config.model_dump())
+
+        # *******************************************
+        # initialise constraints
+        water_depth = WaterDepth(config._DATA_MODE_DEPTH, boat.get_required_water_depth(),
+                                default_map, depthfile)
+        constraints_list = ConstraintsListFactory.get_constraints_list(
+            constraints_string_list=config.CONSTRAINTS_LIST, data_mode=config._DATA_MODE_DEPTH,
+            min_depth=boat.get_required_water_depth(),
+            map_size=default_map, depthfile=depthfile, waypoints=config.INTERMEDIATE_WAYPOINTS,
+            courses_path=config.COURSES_FILE)
+
+        return wt, boat, water_depth, constraints_list
+
+    def __init__(self, config: Config, n_routes: str = "single"):
+        self.config = config
+        self.n_routes = n_routes
+
+        # setup components
+        wt, boat, water_depth, constraints_list = self._setup_components(self.config)
+
+        self.wt: WeatherCond = wt
+        self.boat: Boat = boat
+        self.water_depth: WaterDepth = water_depth
+        self.constraints_list: ConstraintsList = constraints_list
+
+    def generate(self, src, dst, departure_time: datetime) -> Union[np.ndarray, list[np.ndarray]]:
+        cfg = self.config.model_copy(update={
+            "DEFAULT_ROUTE": [*src, *dst],
+            "DEPARTURE_TIME": departure_time
+        })
+
+        # alg is defined in method because route_list is defined per instance,
+        # which wouldn't work well when we want to "generate" multiple times
+        alg = IsoFuel(cfg)
+        alg.path_to_route_folder = None
+
+        min_fuel_route, err_code = alg.execute_routing(
+            boat=self.boat,
+            wt=self.wt,
+            constraints_list=self.constraints_list, )
+
+        # single route
+        if self.n_routes == "single":
+            return np.stack([min_fuel_route.lats_per_step, min_fuel_route.lons_per_step], axis=1)
+
+        # list of routes
+        if not alg.route_list:
+            raise RuntimeError("The Isofuel algorithm couldn't find any route")
+
+        routes = []
+
+        for rt in alg.route_list:
+            routes.append(np.stack([rt.lats_per_step, rt.lons_per_step], axis=1))
+        return routes
+
+    @classmethod
+    def for_multiple_routes(cls, default_map, **kw):
+        cfg = Config.assign_config(
+            path=Path(os.path.dirname(__file__)) / "configs" / "config.isofuel_multiple_routes.json")
+
+        cfg.DEFAULT_MAP = default_map
+
+        for k, v in kw.items():
+            setattr(cfg, k, v)
+
+        return cls(cfg, n_routes="multiple")
+
+    @classmethod
+    def for_single_route(cls, default_map, **kw):
+        cfg = Config.assign_config(
+            path=Path(os.path.dirname(__file__)) / "configs" / "config.isofuel_population.json")
+
+        cfg.DEFAULT_MAP = default_map
+
+        for k, v in kw.items():
+            setattr(cfg, k, v)
+
+        return cls(cfg, n_routes="single")

--- a/WeatherRoutingTool/algorithms/genetic/patcher.py
+++ b/WeatherRoutingTool/algorithms/genetic/patcher.py
@@ -13,14 +13,11 @@ from WeatherRoutingTool.weather import WeatherCond
 from WeatherRoutingTool.ship.ship import Boat
 from WeatherRoutingTool.constraints.constraints import ConstraintsList
 
-
 from WeatherRoutingTool.algorithms.isofuel import IsoFuel
 from WeatherRoutingTool.ship.ship_factory import ShipFactory
 from WeatherRoutingTool.weather_factory import WeatherFactory
 from WeatherRoutingTool.config import Config
-from WeatherRoutingTool.ship.ship_factory import ShipFactory
 from WeatherRoutingTool.utils.maps import Map
-from WeatherRoutingTool.weather_factory import WeatherFactory
 from WeatherRoutingTool.constraints.constraints import ConstraintsListFactory, WaterDepth
 
 
@@ -58,8 +55,9 @@ class IsofuelPatcher:
     """Use the IsoFuel algorithm for route(s) generation
 
     Intuition behind having this as a class:
-    1. The Isofuel path finding component can be quite expensive during the preparation stage (defining map, loading data, etc.).
-        Having setup and execution as separate components could help speed things up.
+    1. The Isofuel path finding component can be quite expensive during the
+        preparation stage (defining map, loading data, etc.). Having setup and
+        execution as separate components could help speed things up.
     """
 
     def _setup_components(self, config):
@@ -78,7 +76,6 @@ class IsofuelPatcher:
         # basic settings
         windfile = config.WEATHER_DATA
         depthfile = config.DEPTH_DATA
-        routepath = config.ROUTE_PATH
         time_resolution = config.DELTA_TIME_FORECAST
         time_forecast = config.TIME_FORECAST
         lat1, lon1, lat2, lon2 = config.DEFAULT_MAP
@@ -87,8 +84,13 @@ class IsofuelPatcher:
 
         # *******************************************
         # initialise weather
-        wt = WeatherFactory.get_weather(config._DATA_MODE_WEATHER, windfile, departure_time, time_forecast, time_resolution,
-                                        default_map)
+        wt = WeatherFactory.get_weather(
+            config._DATA_MODE_WEATHER,
+            windfile,
+            departure_time,
+            time_forecast,
+            time_resolution,
+            default_map, )
 
         # *******************************************
         # initialise boat
@@ -97,13 +99,20 @@ class IsofuelPatcher:
 
         # *******************************************
         # initialise constraints
-        water_depth = WaterDepth(config._DATA_MODE_DEPTH, boat.get_required_water_depth(),
-                                default_map, depthfile)
+        water_depth = WaterDepth(
+            config._DATA_MODE_DEPTH,
+            boat.get_required_water_depth(),
+            default_map,
+            depthfile, )
+
         constraints_list = ConstraintsListFactory.get_constraints_list(
-            constraints_string_list=config.CONSTRAINTS_LIST, data_mode=config._DATA_MODE_DEPTH,
+            constraints_string_list=config.CONSTRAINTS_LIST,
+            data_mode=config._DATA_MODE_DEPTH,
             min_depth=boat.get_required_water_depth(),
-            map_size=default_map, depthfile=depthfile, waypoints=config.INTERMEDIATE_WAYPOINTS,
-            courses_path=config.COURSES_FILE)
+            map_size=default_map,
+            depthfile=depthfile,
+            waypoints=config.INTERMEDIATE_WAYPOINTS,
+            courses_path=config.COURSES_FILE, )
 
         return wt, boat, water_depth, constraints_list
 

--- a/WeatherRoutingTool/algorithms/genetic/population.py
+++ b/WeatherRoutingTool/algorithms/genetic/population.py
@@ -221,7 +221,7 @@ class PopulationFactory:
                     pop_size=population_size, )
 
             case "isofuel":
-                return IsofuelPopulation(
+                return IsoFuelPopulation(
                     config=config,
                     boat=boat,
                     default_route=config.DEFAULT_ROUTE,

--- a/WeatherRoutingTool/algorithms/genetic/population.py
+++ b/WeatherRoutingTool/algorithms/genetic/population.py
@@ -181,7 +181,7 @@ class IsoFuelPopulation(Population):
             default_map=config.DEFAULT_MAP, )
 
     def generate(self, problem, n_samples, **kw):
-        routes = self.patcher.generate(self.src, self.dst, self.departure_time)
+        routes = self.patcher.patch(self.src, self.dst, self.departure_time)
 
         X = np.full((n_samples, 1), None, dtype=object)
 

--- a/WeatherRoutingTool/algorithms/genetic/population.py
+++ b/WeatherRoutingTool/algorithms/genetic/population.py
@@ -13,6 +13,8 @@ from WeatherRoutingTool.constraints.constraints import ConstraintsList
 from WeatherRoutingTool.algorithms.data_utils import GridMixin
 from WeatherRoutingTool.algorithms.genetic import utils
 
+from WeatherRoutingTool.algorithms.genetic import patcher
+
 logger = logging.getLogger("WRT.genetic.population")
 
 
@@ -28,6 +30,19 @@ class Population(Sampling):
 
         self.src: tuple[float, float] = tuple(default_route[:-2])
         self.dst: tuple[float, float] = tuple(default_route[-2:])
+
+    def _do(self, problem, n_samples, **kw):
+        X = self.generate(problem, n_samples, **kw)
+
+        for rt, in X:
+            assert tuple(rt[0]) == self.src, "Source waypoint not matching"
+            assert tuple(rt[-1]) == self.dst, "Destination waypoint not matching"
+
+        self.X = X
+        return self.X
+
+    def generate(self, problem, n_samples, **kw):
+        pass
 
     def check_validity(self, routes):
         """
@@ -47,7 +62,10 @@ class Population(Sampling):
                 self.n_constrained_routes += 1
 
         percentage_constrained = self.n_constrained_routes / self.pop_size
-        assert (percentage_constrained < 0.5), f"{self.n_constrained_routes} / {self.pop_size} constrained — More than 50% of the initial routes are constrained"
+
+        assert (percentage_constrained < 0.5), (
+            f"{self.n_constrained_routes} / {self.pop_size} constrained — "
+            "More than 50% of the initial routes are constrained")
 
 
 class GridBasedPopulation(GridMixin, Population):
@@ -82,8 +100,8 @@ class GridBasedPopulation(GridMixin, Population):
         # ----------
         self.var_type = np.float64
 
-    def _do(self, problem, n_samples, **kw):
-        self.X = routes = np.full((n_samples, 1), None, dtype=object)
+    def generate(self, problem, n_samples, **kw):
+        X = np.full((n_samples, 1), None, dtype=object)
 
         _, _, start_indices = self.coords_to_index([self.src])
         _, _, end_indices = self.coords_to_index([self.dst])
@@ -102,12 +120,10 @@ class GridBasedPopulation(GridMixin, Population):
             _, _, route = self.index_to_coords(route)
 
             # match first and last points to src and dst
-            routes[i, 0] = np.array([
+            X[i, 0] = np.array([
                 self.src, *route[1:-1], self.dst])
 
-        self.check_validity(routes)
-
-        return self.X
+        return X
 
 
 class FromGeojsonPopulation(Population):
@@ -124,14 +140,14 @@ class FromGeojsonPopulation(Population):
             raise FileNotFoundError("Routes directory not found")
         self.routes_dir: str = routes_dir
 
-    def _do(self, problem, n_samples, **kw):
+    def generate(self, problem, n_samples, **kw):
         logger.debug(f"Population from geojson routes: {self.routes_dir}")
 
         # routes are expected to be named in the following format:
         # route_{1..N}.json
         # example: route_1.json, route_2.json, route_3.json, ...
 
-        self.X = routes = np.full((n_samples, 1), None, dtype=object)
+        X = np.full((n_samples, 1), None, dtype=object)
 
         for i in range(n_samples):
             path = os.path.join(self.routes_dir, f"route_{i + 1}.json")
@@ -145,10 +161,37 @@ class FromGeojsonPopulation(Population):
             assert np.array_equal(route[0], self.src), "Route not starting at source"
             assert np.array_equal(route[-1], self.dst), "Route not ending at destination"
 
-            routes[i, 0] = np.array(route)
+            X[i, 0] = np.array(route)
 
-        self.check_validity(routes)
-        return routes
+        return X
+
+
+class IsoFuelPopulation(Population):
+    """Population generation using the Isofuel algorithm"""
+
+    def __init__(self, config: Config, boat: Boat, default_route, constraints_list, pop_size):
+        super().__init__(
+            default_route=default_route,
+            constraints_list=constraints_list,
+            pop_size=pop_size, )
+
+        self.departure_time = config.DEPARTURE_TIME
+
+        self.patcher = patcher.IsofuelPatcher.for_multiple_routes(
+            default_map=config.DEFAULT_MAP, )
+
+    def generate(self, problem, n_samples, **kw):
+        routes = self.patcher.generate(self.src, self.dst, self.departure_time)
+
+        X = np.full((n_samples, 1), None, dtype=object)
+
+        for i, rt in enumerate((routes)):
+            X[i, 0] = np.array([self.src, *rt[1:-1], self.dst])
+
+        # fallback: fill all other individuals with the same population as the last one
+        for j in range(i + 1, n_samples):
+            X[j, 0] = np.copy(X[j - 1, 0])
+        return X
 
 
 class PopulationFactory:
@@ -172,19 +215,25 @@ class PopulationFactory:
         match population_type:
             case "grid_based":
                 return GridBasedPopulation(
-                    default_route=config.DEFAULT_ROUTE,
                     grid=wave_height,
+                    default_route=config.DEFAULT_ROUTE,
                     constraints_list=constraints_list,
-                    pop_size=population_size
-                )
+                    pop_size=population_size, )
+
+            case "isofuel":
+                return IsofuelPopulation(
+                    config=config,
+                    boat=boat,
+                    default_route=config.DEFAULT_ROUTE,
+                    constraints_list=constraints_list,
+                    pop_size=population_size, )
 
             case "from_geojson":
                 return FromGeojsonPopulation(
-                    default_route=config.DEFAULT_ROUTE,
                     routes_dir=config.GENETIC_POPULATION_PATH,
+                    default_route=config.DEFAULT_ROUTE,
                     constraints_list=constraints_list,
-                    pop_size=population_size
-                )
+                    pop_size=population_size, )
 
             case _:
                 logger.error(f"Population type invalid: {population_type}")

--- a/WeatherRoutingTool/algorithms/genetic/repair.py
+++ b/WeatherRoutingTool/algorithms/genetic/repair.py
@@ -1,11 +1,121 @@
 from pymoo.core.repair import Repair, NoRepair
 
+import numpy as np
 import logging
+
+from WeatherRoutingTool.config import Config
+from WeatherRoutingTool.constraints.constraints import ConstraintsList
+from WeatherRoutingTool.algorithms.genetic import utils, patcher
 
 logger = logging.getLogger("WRT.genetic.repair")
 
 
+# ----------
+class RepairBase(Repair):
+    def __init__(self, config: Config):
+        super().__init__()
+
+        self.config = config
+
+    def _do(self, problem, X, **kw):
+        return self.repairfn(problem, X, **kw)
+
+    def repairfn(self, problem, X, **kw):
+        pass
+
+
+# repair implementations
+# ----------
+class WaypointsInfillRepair(RepairBase):
+    """Repair routes by infilling them with equi-distant points when
+    adjacent points are farther than the specified distance resolution (gcr_dist)
+    """
+
+    def repairfn(self, problem, X, **kw):
+        gcr_dist = 1e5
+        patchfn = patcher.GreatCircleRoutePatcher(dist=gcr_dist)
+
+        for i, (rt,) in enumerate(X):
+            route = []
+
+            for j in range(rt.shape[0] - 1):
+                p1, p2 = rt[[j, j+1]]
+                d = utils.gcr_distance(p1, p2)
+
+                # patch with new waypoints if the distance between any 2
+                # adjacent points is greater than 2x the gcr_dist (resolution)
+
+                if not d >= gcr_dist * 2:
+                    route.append([p1])
+                else:
+                    route.append(
+                        patchfn.patch(p1, p2, self.config.DEPARTURE_TIME)[:-1])
+
+            route.append(rt[[-1]])
+            X[i, 0] = np.concatenate(route, axis=0)
+        return X
+
+
+class ConstraintViolationRepair(RepairBase):
+    """Repair routes by finding a feasible route between constraint violations
+    """
+
+    def __init__(self, config: Config, constraints_list, **kw):
+        super().__init__(config=config)
+
+        self.constraints_list = constraints_list
+
+    def repairfn(self, problem, X, **kw):
+        # gcr_dist = 1e5
+        # patchfn = patcher.GreatCircleRoutePatcher(dist=gcr_dist)
+
+        patchfn = patcher.IsofuelPatcher.for_single_route(self.config.DEFAULT_MAP)
+
+        for i, (rt,) in enumerate(X):
+            constrained = utils.get_constraints_array(rt, self.constraints_list)
+            nr = [rt[[0]]]
+
+            p = 0
+
+            for j in range(1, constrained.shape[0]):
+                v = constrained[j]
+
+                if v != 0:
+                    continue
+
+                if j - p > 1:
+                    _r = patchfn.patch(rt[p], rt[j], self.config.DEPARTURE_TIME)
+                    nr.append(_r[1:])
+                else:
+                    nr.append(rt[[j]])
+                p = j
+
+            X[i, 0] = np.concatenate(nr, axis=0)
+        return X
+
+
+# orchestration
+# ----------
+class ChainedRepair(Repair):
+    def __init__(self, order):
+        super().__init__()
+
+        self.order = order
+
+    def _do(self, problem, X, **kw):
+        for rep in self.order:
+            X = rep._do(problem, X, **kw)
+
+        return X
+
+
+# factory
+# ----------
 class RepairFactory:
     @staticmethod
-    def get_repair():
-        return NoRepair()
+    def get_repair(config: Config, constraints_list: ConstraintsList):
+        return ChainedRepair(
+            order=[
+                WaypointsInfillRepair(config),
+                ConstraintViolationRepair(config, constraints_list)
+            ], )

--- a/WeatherRoutingTool/algorithms/genetic/utils.py
+++ b/WeatherRoutingTool/algorithms/genetic/utils.py
@@ -9,6 +9,13 @@ import json
 import math
 
 
+def gcr_distance(src, dst) -> float:
+    geod = Geodesic.WGS84
+
+    rs = geod.Inverse(*src, *dst)
+    return rs["s12"]
+
+
 def great_circle_distance(src, dst) -> float:
     """Measure great circle distance between src and dst waypoints
 

--- a/WeatherRoutingTool/algorithms/genetic/utils.py
+++ b/WeatherRoutingTool/algorithms/genetic/utils.py
@@ -9,36 +9,6 @@ import json
 import math
 
 
-@functools.cache
-def great_circle_route(
-        src: tuple[float, float],
-        dst: tuple[float, float],
-        distance=100_000.0
-) -> list[tuple[float, float]]:
-    """Generate equi-distant waypoints across the Great Circle Route from src to
-    dst
-
-    :param src: Source waypoint as (lat, lon) pair
-    :type src: tuple[float, float]
-    :param dst: Destination waypoint as (lat, lon) pair
-    :type dst: tuple[float, float]
-    :param distance: Distance between waypoints generated
-    :type distance: float
-    :return: List of waypoints along the great circle (lat, lon)
-    :rtype: list[tuple[float, float]]
-    """
-
-    geod: Geodesic = Geodesic.WGS84
-    line = geod.InverseLine(*src, *dst)
-    n = int(math.ceil(line.s13 / distance))
-    route = []
-    for i in range(n + 1):
-        s = min(distance * i, line.s13)
-        g = line.Position(s, Geodesic.STANDARD | Geodesic.LONG_UNROLL)
-        route.append((g['lat2'], g['lon2']))
-    return [src, *route[1:-1], dst]
-
-
 def great_circle_distance(src, dst) -> float:
     """Measure great circle distance between src and dst waypoints
 

--- a/WeatherRoutingTool/algorithms/genetic/utils.py
+++ b/WeatherRoutingTool/algorithms/genetic/utils.py
@@ -92,10 +92,14 @@ def geojson_from_route(
     return geojson
 
 
-def get_constraints(route, constraint_list):
-    # ToDo: what about time?
-    constraints = np.sum(get_constraints_array(route, constraint_list))
-    return constraints
+# constraints
+def is_neg_constraints(lat, lon, time, constraint_list):
+    lat = np.array([lat])
+    lon = np.array([lon])
+    is_constrained = [False for i in range(0, lat.shape[0])]
+    is_constrained = constraint_list.safe_endpoint(lat, lon, time, is_constrained)
+    # print(is_constrained)
+    return 0 if not is_constrained else 1
 
 
 def get_constraints_array(route: np.ndarray, constraint_list) -> np.ndarray:
@@ -106,17 +110,15 @@ def get_constraints_array(route: np.ndarray, constraint_list) -> np.ndarray:
     :type route: np.ndarray
     :return: Array of constraint violations
     """
-    constraints = np.array([is_neg_constraints(lat, lon, None, constraint_list) for lat, lon in route])
+    constraints = np.array([
+        is_neg_constraints(lat, lon, None, constraint_list) for lat, lon in route])
     return constraints
 
 
-def is_neg_constraints(lat, lon, time, constraint_list):
-    lat = np.array([lat])
-    lon = np.array([lon])
-    is_constrained = [False for i in range(0, lat.shape[0])]
-    is_constrained = constraint_list.safe_endpoint(lat, lon, time, is_constrained)
-    # print(is_constrained)
-    return 0 if not is_constrained else 1
+def get_constraints(route, constraint_list):
+    # ToDo: what about time?
+    constraints = np.sum(get_constraints_array(route, constraint_list))
+    return constraints
 
 
 def route_from_geojson(dt: dict) -> list[tuple[float, float]]:

--- a/WeatherRoutingTool/config.py
+++ b/WeatherRoutingTool/config.py
@@ -79,7 +79,7 @@ class Config(BaseModel):
     GENETIC_NUMBER_GENERATIONS: int = 20  # number of generations for genetic algorithm
     GENETIC_NUMBER_OFFSPRINGS: int = 2  # number of offsprings for genetic algorithm
     GENETIC_POPULATION_SIZE: int = 20  # population size for genetic algorithm
-    GENETIC_POPULATION_TYPE: Literal['grid_based', 'from_geojson'] = 'grid_based'  # type for initial population
+    GENETIC_POPULATION_TYPE: Literal['grid_based', 'from_geojson', 'isofuel'] = 'grid_based'  # type for initial population
     # (options: 'grid_based', 'from_geojson')
     GENETIC_POPULATION_PATH: Optional[str] = None  # path to initial population
 
@@ -388,10 +388,10 @@ class Config(BaseModel):
                 map_coords = self.DEFAULT_MAP
                 if map_coords:
                     lat_min, lon_min, lat_max, lon_max = map_coords
-                    if not (lat.min() <= lat_min <= lat.max() and
-                            lat.min() <= lat_max <= lat.max() and
-                            lon.min() <= lon_min <= lon.max() and
-                            lon.min() <= lon_max <= lon.max()):
+                    if not (round(lat.min()) <= lat_min <= round(lat.max()) and
+                            round(lat.min()) <= lat_max <= round(lat.max()) and
+                            round(lon.min()) <= lon_min <= round(lon.max()) and
+                            round(lon.min()) <= lon_max <= round(lon.max())):
                         raise ValueError("Depth data does not cover the map region.")
 
             except Exception as e:

--- a/WeatherRoutingTool/config.py
+++ b/WeatherRoutingTool/config.py
@@ -388,10 +388,10 @@ class Config(BaseModel):
                 map_coords = self.DEFAULT_MAP
                 if map_coords:
                     lat_min, lon_min, lat_max, lon_max = map_coords
-                    if not (round(lat.min()) <= lat_min <= round(lat.max()) and
-                            round(lat.min()) <= lat_max <= round(lat.max()) and
-                            round(lon.min()) <= lon_min <= round(lon.max()) and
-                            round(lon.min()) <= lon_max <= round(lon.max())):
+                    if not (lat.min() <= lat_min <= lat.max() and
+                            lat.min() <= lat_max <= lat.max() and
+                            lon.min() <= lon_min <= lon.max() and
+                            lon.min() <= lon_max <= lon.max()):
                         raise ValueError("Depth data does not cover the map region.")
 
             except Exception as e:


### PR DESCRIPTION
## `WaypointsInfillRepair`
Repairs routes by infilling them with equi-distant points when adjacent points are farther than 2 times the specified distance resolution (`gcr_dist`).

This ensures waypoints in an individual don't skip over large distances resulting in an inaccurate representation of constraint violations.

## `ConstraintViolationRepair`
Repairs routes by finding a feasible route across waypoints that are violating constraints. This uses the IsoFuel patcher for finding feasible route patching.

## `ChainedRepair`
Repair class to chain multiple repair operations in the order passed in. It runs all the repair classes in the same order for the entire population.