### PR TITLE
Fix doc formatting: add missing triple quotes and update pip commands… (#97)

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -20,8 +20,11 @@ Example:
 
 .. code-block:: python
 
-    This is a reStructuredText style.
+
     """
+
+    This is a reStructuredText style.
+
     :param param1: first param
     :type param1: type of first param
     :return: description of what is returned

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,7 +12,7 @@ Steps:
   - ``source venv/bin/activate``
 - install the WRT: ``pip install . && pip install --no-deps -r requirements-without-deps.txt`` or in editable mode (recommended for development) ``pip install -e . && pip install --no-deps -r requirements-without-deps.txt``
 
-The part `pip install --no-deps -r requirements-without-deps.txt` is necessary because of a dependency issue (see https://github.com/52North/WeatherRoutingTool/issues/8). We might implement a different solution in the future making the installation easier/cleaner.
+The part ``pip install --no-deps -r requirements-without-deps.txt`` is necessary because of a dependency issue (see https://github.com/52North/WeatherRoutingTool/issues/8). We might implement a different solution in the future making the installation easier/cleaner.
 
 **Power/fuel consumption framework**
 


### PR DESCRIPTION
Added missing opening triple quotes in docstring example

Updated pip install commands to use double backticks for correct rest formatting