### PR TITLE
Improved fallback strategy for initial population generation.

### DIFF
--- a/WeatherRoutingTool/algorithms/genetic/population.py
+++ b/WeatherRoutingTool/algorithms/genetic/population.py
@@ -175,8 +175,9 @@ class IsoFuelPopulation(Population):
 
     Produces initial routes using the IsoFuel algorithm's
     ISOCHRONE_NUMBER_OF_STEPS configuration. If the number of generated routes
-    is lesser than the expected n_samples number of individuals, the last
-    produced route is repeated until the required number of individuals are met
+    is lesser than the expected n_samples number of individuals, produced routes are 
+    cloned and noise is added to the cloned routes until the required number of 
+    individuals are met.
     """
 
     def __init__(self, config: Config, boat: Boat, default_route, constraints_list, pop_size):


### PR DESCRIPTION
## Description 
This PR changes the fallback strategy for initial population generation, related to  #109   issue.
Instead of creating exact clones, now the changed, fallback strategy creates slight variations in the clones . This process is often called "perturbation" or "jittering."

## Files Modified 
WeatherRoutingTool\algorithms\genetic\population.py
