### PR TITLE
Fix undefined neg_size in ConstraintsList.have_negative

### DIFF
--- a/WeatherRoutingTool/constraints/constraints.py
+++ b/WeatherRoutingTool/constraints/constraints.py
@@ -271,10 +271,8 @@ class ConstraintsList:
             return False
 
     def have_negative(self):
-        if self.neg_size > 0:
-            return True
-        else:
-            return False
+        return (self.neg_dis_size + self.neg_cont_size) > 0
+
 
     def init_positive_lists(self, start, finish):
         lat = []


### PR DESCRIPTION
### Summary
Fixes a runtime `AttributeError` in `ConstraintsList.have_negative` caused by referencing an undefined attribute.

### Problem
The `ConstraintsList` class initializes the following attributes in `__init__`:
- `neg_dis_size`
- `neg_cont_size`
- `pos_size`

However, the method `have_negative()` attempted to access `self.neg_size`, which is never defined.  
This resulted in the following runtime error on valid code paths:

AttributeError: 'ConstraintsList' object has no attribute 'neg_size'


### Solution
- Updated `have_negative()` to rely exclusively on existing negative constraint size attributes
- Ensures correct detection of negative constraints
- Prevents runtime crashes

### Impact
- Fixes a medium-severity bug
- Improves robustness of constraint handling
- No breaking changes introduced

### Testing
- Existing tests pass
- Change is limited to internal logic only

Fixes #118
