### PR TITLE
Fix have_negative() using correct constraint attributes

### DIFF
--- a/WeatherRoutingTool/constraints/constraints.py
+++ b/WeatherRoutingTool/constraints/constraints.py
@@ -271,7 +271,7 @@ class ConstraintsList:
             return False
 
     def have_negative(self):
-        if self.neg_size > 0:
+        if self.neg_dis_size > 0 or self.neg_cont_size > 0:
             return True
         else:
             return False


### PR DESCRIPTION
### Issue

The method `have_negative()` referenced a non-existent attribute
`neg_size`, causing a runtime error, related to #118 issue.

### Fix
Updated the method to correctly use `neg_dis_size` and
`neg_cont_size`.

### Impact
Prevents AttributeError and ensures correct constraint detection.
