### PR TITLE
document known speedy isobased pruning limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A tool to perform optimization of ship routes based on fuel consumption in diffe
 
 Documentation: https://52north.github.io/WeatherRoutingTool/
 
+- Full documentation: https://52north.github.io/WeatherRoutingTool/
+- Known issues: docs/known_issues.md
+
+
 Introduction: [WRT-sandbox](https://github.com/52North/WRT-sandbox) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/52North/WRT-sandbox.git/HEAD?urlpath=%2Fdoc%2Ftree%2FNotebooks/execute-WRT.ipynb)
 
 ## Funding


### PR DESCRIPTION
This PR documents a known limitation of the `speedy_isobased` routing
algorithm when using the provided test weather and depth datasets.

The routing may terminate early with all pruning segments constrained,
even though no runtime error occurs. This change explains the symptoms,
likely cause, and suggests parameter workarounds to help new users
understand and mitigate the behavior.

Related issue: #105
