### PR TITLE
Add known issues documentation for speedy routing

### DIFF
--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -1,0 +1,31 @@
+---
+
+## Known Issues
+
+### Speedy IsoBased Routing with Test Data
+
+When using the `speedy_isobased` algorithm with the provided
+test weather and depth datasets, routing may terminate early
+with the error:
+
+> All pruning segments fully constrained
+
+#### Symptoms
+- Routing stops after ~10–11 isochrone steps
+- No runtime exception occurs
+- No route reaches the destination
+- A partial route file is generated with 0% success
+
+#### Cause (Observed)
+This occurs when all isochrone pruning segments become constrained
+due to the interaction of:
+- Pruning parameters
+- Environmental constraints (land, depth, map bounds)
+- Test data resolution
+
+#### Suggested Workarounds
+Users may try:
+- Increasing `ISOCHRONE_PRUNE_SEGMENTS`
+- Reducing `ISOCHRONE_PRUNE_SECTOR_DEG_HALF`
+- Increasing heading resolution
+- Reducing pruning strictness


### PR DESCRIPTION
# Related Issue / Discussion

Relates to discussion: https://github.com/52North/WeatherRoutingTool/issues/105

# Changes

The following documentation changes were implemented:

- **Modified** documentation to describe a known limitation of the `speedy_isobased` routing algorithm when used with the provided test weather and depth datasets.
- **Added** explanation of the symptoms users may experience when the routing algorithm fails to reach the destination.
- **Added** documentation describing possible causes of the issue.
- **Added** configuration suggestions and workarounds to help users avoid confusion when running the example datasets.

# Further Details

## Summary

This pull request improves the documentation of the WeatherRoutingTool by describing a known limitation of the `speedy_isobased` routing algorithm when used with the provided test weather and depth datasets.

Before the modification:
- Users running the example datasets could experience situations where the `speedy_isobased` routing algorithm fails to reach the destination.
- This behavior was not clearly documented, which could lead to confusion for new users.

After the modification:
- The documentation explains the symptoms of this issue.
- The likely causes of the behavior are described.
- Possible configuration workarounds are suggested to help users run the routing tool successfully.

These changes aim to improve the user experience and reduce confusion for new users working with the example datasets.

## Dependencies

No new dependencies are required for this modification.  
This PR only updates documentation.

# PR Checklist

In the context of this PR, I:

- [x] have (already previously) filled the 52North Contributor License Agreement and received positive feedback on this matter
- [x] have filled the 52North Contributor License Agreement and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework (not applicable since this PR only modifies documentation)
- [x] ensure that the code formatter runs without errors/warnings
- [x] ensure that my changes follow the WRT’s guidelines for contributing at the time of the contribution