### PR TITLE
Skip manual plotting tests in default pytest runs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ markers =
     genetic: tests for genetic algorithm
     maripower: tests that need maripower support
     manual: tests that produce figures as output
-addopts = -ra --tb=short --strict-markers
+addopts = -ra --tb=short --strict-markers  -m "not manual"
 
 
 


### PR DESCRIPTION
# Related Issue / Discussion:

Fixes Issue #N/A

Relates to discussion [link] N/A

# Changes: 
- Modified pytest.ini to exclude @pytest.mark.manual tests from default pytest runs.


- **Modified** pytest.ini


# Further Details:

## Summary:

Some tests in test_genetic are marked with @pytest.mark.manual and require interactive plotting using matplotlib.
These tests currently run during normal pytest execution and fail due to missing fixtures and non-interactive backends.

This PR updates pytest configuration to skip manual tests by default while keeping them executable via `pytest -m manual`.
This improves CI stability and developer experience without removing manual test coverage.


## Dependencies:

No new dependencies are introduced.



# PR Checklist:

In the context of this PR, I:
- [ ] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [x ] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [x ] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x ] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x ] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution

Please consider that PRs which do not meet the requirements specified in the checklist will not be evaluated. Also, PRs with no activities will be closed after a reasonable amount of time.
