### PR TITLE
Fix incorrect `Path(path).exists` usage in Config and ShipConfig loaders

### DIFF
--- a/WeatherRoutingTool/config.py
+++ b/WeatherRoutingTool/config.py
@@ -189,7 +189,12 @@ class Config(BaseModel):
         """
 
         if init_mode == 'from_json':
-            if Path(path).exists:
+            if path is None:
+                raise ValueError("You chose init_mode = 'from_json' but path has no value")
+
+            path = Path(path)
+
+            if path.exists():
                 with path.open("r") as f:
                     config_data = json.load(f)
                     config = cls.validate_config(config_data)

--- a/WeatherRoutingTool/ship/ship_config.py
+++ b/WeatherRoutingTool/ship/ship_config.py
@@ -65,10 +65,20 @@ class ShipConfig(BaseModel):
 
     @classmethod
     def assign_config(cls, path=None, init_mode='from_json', config_dict=None):
-        if init_mode == 'from_json' and Path(path).exists:
-            with path.open("r") as f:
-                config_data = json.load(f)
-            return cls.validate_config(config_data)
+        if init_mode == 'from_json':
+            if path is None:
+                raise ValueError("You chose init_mode = 'from_json' but path has no value")
+
+            path = Path(path)
+
+            if path.exists():
+                with path.open("r") as f:
+                    config_data = json.load(f)
+                return cls.validate_config(config_data)
+            else:
+                msg = f"Path to ship config doesn't exist: {path}"
+                logger.error(msg)
+                raise ValueError(msg)
         elif init_mode == 'from_dict':
             return cls.validate_config(config_dict)
         else:


### PR DESCRIPTION
# Related Issue / Discussion:

Please delete the option which is not relevant.

Fixes Issue #143 Fix incorrect `Path(path).exists` usage in config loaders

---

# Changes:

Please list the central functionalities that have been changed:

* **Modified** `WeatherRoutingTool/config.py`
* **Modified** `WeatherRoutingTool/ship/ship_config.py`

---

# Further Details:

## Summary:

This PR fixes incorrect file existence checks in the configuration loading logic.

Previously, both `Config.assign_config` and `ShipConfig.assign_config` used:

```python
if Path(path).exists:
```

Since `exists` is a method, not calling it results in a truthy method object, causing the condition to always evaluate to `True`. This could silently accept invalid paths and later fail during file operations with less clear errors.

### Changes introduced:

* Normalize the input using `path = Path(path)` to consistently support both `str` and `Path`.
* Replace `Path(path).exists` with `path.exists()` (proper method call).
* Raise a clear `ValueError` when:

  * `init_mode == "from_json"` and `path` is `None`
  * The provided configuration file does not exist.

### Behavior before:

* Invalid paths could pass the existence check.
* Errors occurred later during file access, potentially producing less clear exceptions.

### Behavior after:

* File existence is properly validated.
* Missing or invalid paths raise clear and explicit `ValueError`s.
* Behavior for valid configuration files remains unchanged.

No functional behavior has been modified for valid inputs.

---

## Dependencies:

No new dependencies were introduced.

---

# PR Checklist:

In the context of this PR, I:

- [x] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter 
- [ ] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback 
- [x] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages. 
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings 
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution

Please consider that PRs which do not meet the requirements specified in the checklist will not be evaluated. Also, PRs with no activities will be closed after a reasonable amount of time.