### PR TITLE
Fix: Make `ARRIVAL_TIME` validation consistent and remove invalid sentinel default

### DIFF
--- a/WeatherRoutingTool/config.py
+++ b/WeatherRoutingTool/config.py
@@ -56,7 +56,7 @@ class Config(BaseModel):
     ALGORITHM_TYPE: Literal[
         'dijkstra', 'gcr_slider', 'genetic', 'genetic_shortest_route', 'isofuel', 'speedy_isobased'
     ] = 'isofuel'
-    ARRIVAL_TIME: datetime = '9999-99-99T99:99Z'  # arrival time at destination, format: 'yyyy-mm-ddThh:mmZ'
+    ARRIVAL_TIME: Optional[datetime] = None  # arrival time at destination, format: 'yyyy-mm-ddThh:mmZ'
 
     BOAT_TYPE: Literal['CBT', 'SAL', 'speedy_isobased', 'direct_power_method'] = 'direct_power_method'
     BOAT_SPEED: float = -99.  # boat speed [m/s]
@@ -209,15 +209,28 @@ class Config(BaseModel):
 
     @field_validator('DEPARTURE_TIME', 'ARRIVAL_TIME', mode='before')
     @classmethod
-    def parse_and_validate_datetime(cls, v):
+    def parse_and_validate_datetime(cls, v, info: ValidationInfo):
+        field_name = info.field_name
+
+        # Allow ARRIVAL_TIME to be omitted or explicitly set to None
+        if v is None:
+            if field_name == 'ARRIVAL_TIME':
+                return None
+            raise ValueError(f"'{field_name}' must be in format YYYY-MM-DDTHH:MMZ")
+
         if isinstance(v, datetime):
             return v
 
-        try:
-            dt = datetime.strptime(v, '%Y-%m-%dT%H:%MZ')
-            return dt
-        except ValueError:
-            raise ValueError("'DEPARTURE_TIME' must be in format YYYY-MM-DDTHH:MMZ")
+        if isinstance(v, str):
+            # Backward compatibility: treat the old sentinel string for ARRIVAL_TIME as "not set"
+            if field_name == 'ARRIVAL_TIME' and v == '9999-99-99T99:99Z':
+                return None
+            try:
+                return datetime.strptime(v, '%Y-%m-%dT%H:%MZ')
+            except ValueError:
+                raise ValueError(f"'{field_name}' must be in format YYYY-MM-DDTHH:MMZ")
+
+        raise ValueError(f"'{field_name}' must be a datetime or string in format YYYY-MM-DDTHH:MMZ")
 
     @field_validator('COURSES_FILE', 'ROUTE_PATH', 'DIJKSTRA_MASK_FILE', 'GENETIC_POPULATION_PATH',
                      mode='after')
@@ -478,11 +491,14 @@ class Config(BaseModel):
     def check_speed_determination(self) -> Self:
         logger.info(f'arrival time: {self.ARRIVAL_TIME}')
         logger.info(f'speed: {self.BOAT_SPEED}')
-        if self.ARRIVAL_TIME == '9999-99-99T99:99Z' and self.BOAT_SPEED == -99.:
+        arrival_time_specified = self.ARRIVAL_TIME is not None
+        boat_speed_specified = self.BOAT_SPEED != -99.
+
+        if not arrival_time_specified and not boat_speed_specified:
             raise ValueError('Please specify either the boat speed or the arrival time')
-        if not self.ARRIVAL_TIME == '9999-99-99T99:99Z' and not self.BOAT_SPEED == -99.:
+        if arrival_time_specified and boat_speed_specified:
             raise ValueError('Please specify either the boat speed or the arrival time and not both.')
-        if not self.ARRIVAL_TIME == '9999-99-99T99:99Z' and self.ALGORITHM_TYPE != 'genetic':
+        if arrival_time_specified and self.ALGORITHM_TYPE != 'genetic':
             raise ValueError('The determination of the speed from the arrival time is only possible for the'
                              ' genetic algorithm')
         return self

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,6 +38,40 @@ def test_invalid_time_raises_error():
     assert "'DEPARTURE_TIME' must be in format YYYY-MM-DDTHH:MMZ" in str(excinfo.value)
 
 
+def test_arrival_time_optional_when_omitted():
+    """Config validation should succeed when ARRIVAL_TIME is not provided."""
+    config_data, _ = load_example_config()
+    # ARRIVAL_TIME is intentionally omitted in the example config
+    assert "ARRIVAL_TIME" not in config_data
+
+    config = Config.assign_config(init_mode="from_dict", config_dict=config_data)
+
+    assert config.ARRIVAL_TIME is None
+
+
+def test_both_arrival_time_and_boat_speed_specified_raises_error():
+    """Config validation should reject when both ARRIVAL_TIME and BOAT_SPEED are specified."""
+    config_data, _ = load_example_config()
+    config_data["ALGORITHM_TYPE"] = "genetic"
+    config_data["ARRIVAL_TIME"] = "2025-04-02T11:11Z"
+
+    with pytest.raises(ValueError) as excinfo:
+        Config.assign_config(init_mode="from_dict", config_dict=config_data)
+
+    assert "Please specify either the boat speed or the arrival time and not both." in str(excinfo.value)
+
+
+def test_neither_arrival_time_nor_boat_speed_specified_raises_error():
+    """Config validation should reject when neither ARRIVAL_TIME nor BOAT_SPEED is specified."""
+    config_data, _ = load_example_config()
+    config_data["BOAT_SPEED"] = -99.
+
+    with pytest.raises(ValueError) as excinfo:
+        Config.assign_config(init_mode="from_dict", config_dict=config_data)
+
+    assert "Please specify either the boat speed or the arrival time" in str(excinfo.value)
+
+
 def test_invalid_path_raises_error(tmp_path):
     config_data, _ = load_example_config()
     config_data["ROUTE_PATH"] = str(tmp_path / "nonexistent.nc")


### PR DESCRIPTION
# Related Issue / Discussion:

Fixes Issue #145
---

# Changes:

* **Modified** `WeatherRoutingTool/config.py`

  * Changed `ARRIVAL_TIME` to `Optional[datetime] = None`
  * Updated datetime validation logic to handle `None` correctly
  * Corrected error messages to reference the validated field name
  * Replaced sentinel string comparisons with `None` checks in `check_speed_determination`
  * Added backward compatibility for legacy sentinel string (`'9999-99-99T99:99Z'`)

* **Modified** `WeatherRoutingTool/tests/test_config.py`

  * Added unit tests covering:

    * `ARRIVAL_TIME` omitted
    * Both `ARRIVAL_TIME` and `BOAT_SPEED` specified
    * Neither specified
    * Invalid datetime format validation

---

# Further Details:

## Summary:

Previously, `ARRIVAL_TIME` was typed as `datetime` but used the string sentinel `'9999-99-99T99:99Z'` as a default value. This string is not a valid datetime and required string comparisons in validation logic.

Additionally, the datetime validator emitted error messages that referenced only `DEPARTURE_TIME`, even when validating `ARRIVAL_TIME`.

This PR:

* Replaces the sentinel string with `None` using `Optional[datetime]`
* Updates validation logic to rely on semantic `None` checks
* Corrects error messages to reflect the validated field
* Preserves backward compatibility by treating the legacy sentinel string as an alias for “unset”
* Adds unit tests to ensure consistent behavior

Behavioral outcome:

* Validation succeeds when `ARRIVAL_TIME` is omitted
* Validation fails if both `ARRIVAL_TIME` and `BOAT_SPEED` are specified
* Validation fails if neither is specified
* Error messages correctly reference the validated field

This improves type consistency, simplifies validation logic, and maintains existing functionality.

---

## Dependencies:

No new dependencies introduced.

---

# PR Checklist:

In the context of this PR, I:
- [x] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [ ] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution

Please consider that PRs which do not meet the requirements specified in the checklist will not be evaluated. Also, PRs with no activities will be closed after a reasonable amount of time.

---