### PR TITLE
fix: correct Path.exists() call and error message in config validation

### DIFF
--- a/WeatherRoutingTool/config.py
+++ b/WeatherRoutingTool/config.py
@@ -189,7 +189,7 @@ class Config(BaseModel):
         """
 
         if init_mode == 'from_json':
-            if Path(path).exists:
+            if Path(path).exists():
                 with path.open("r") as f:
                     config_data = json.load(f)
                     config = cls.validate_config(config_data)
@@ -283,7 +283,7 @@ class Config(BaseModel):
         :rtype: tuple
         """
         if len(v) != 4:
-            raise ValueError("Coordinate list must contain exactly 4 values: [lat_min, lon_max, lat_end, lon_end]")
+            raise ValueError("Coordinate list must contain exactly 4 values: [lat_min, lon_min, lat_max, lon_max]")
 
         lat_start, lon_start, lat_end, lon_end = v
 


### PR DESCRIPTION
This PR fixes two issues in `config.py`:

1. **Bug fix:** In `assign_config()`, `Path(path).exists` was checking the method reference (always truthy) instead of calling `Path(path).exists()`. This meant the path existence check was silently skipped.
2. **Error message fix:** In `validate_map_coordinates()`, the error message incorrectly listed the parameter format as `[lat_min, lon_max, lat_end, lon_end]` instead of `[lat_min, lon_min, lat_max, lon_max]`.