### PR TITLE
Fix boat speed sentinel handling in `RoutingAlg`

### DIFF
--- a/WeatherRoutingTool/algorithms/routingalg.py
+++ b/WeatherRoutingTool/algorithms/routingalg.py
@@ -52,7 +52,11 @@ class RoutingAlg:
 
         self.boat_speed = config.BOAT_SPEED
         if self.boat_speed is not None:
-            self.boat_speed = self.boat_speed * u.meter / u.second
+            if self.boat_speed == -99:
+                # Sentinel value indicating that no fixed speed is configured
+                self.boat_speed = None
+            else:
+                self.boat_speed = self.boat_speed * u.meter / u.second
 
     def get_boat_speed(self):
         return self.boat_speed


### PR DESCRIPTION
# Related Issue / Discussion:

Fixes Issue #156 

# Changes: 
- **Modified** `WeatherRoutingTool/algorithms/routingalg.py` to handle the boat speed sentinel value consistently and safely


# Further Details:

## Summary:

Previously, `RoutingAlg` always converted `config.BOAT_SPEED` into an astropy `Quantity` when it was non-`None`, which meant that the sentinel value `-99` (used throughout the project as a “dummy/unset” marker) was turned into a physically meaningless `-99 m/s`. This allowed an unset boat speed to propagate into downstream calculations instead of being treated as missing.

This PR updates `RoutingAlg.__init__` so that when `config.BOAT_SPEED` is `-99`, `self.boat_speed` is set to `None` rather than converted to a `Quantity`. As a result, `get_boat_speed()` now returns `None` when the configuration uses the sentinel, and a proper `Quantity` otherwise. This aligns `RoutingAlg` with the existing sentinel handling in the genetic algorithm and other parts of the codebase and avoids any improper `Quantity`–scalar comparisons.

## Dependencies:

No new dependencies introduced.


# PR Checklist:

In the context of this PR, I:
- [ ] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [x] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution

Please consider that PRs which do not meet the requirements specified in the checklist will not be evaluated. Also, PRs with no activities will be closed after a reasonable amount of time.
