### PR TITLE
fix(test): correct dead test functions for get_u/get_v in test_weather.py

### DIFF
--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,6 +1,10 @@
+import math
+
 import pytest
 
 from WeatherRoutingTool.weather import WeatherCond
+
+SQRT2_2 = math.sqrt(2) / 2
 
 
 @pytest.mark.parametrize("u,v,theta_res", [(-1, -1, 45), (1, -1, 315), (1, 1, 225), (-1, 1, 135)])
@@ -10,15 +14,57 @@ def test_theta_from_uv(u, v, theta_res):
     assert theta_test == pytest.approx(theta_res)
 
 
-@pytest.mark.parametrize("theta,windspeed,u_res", [(45, 1, -1), (315, 1, 1), (225, 1, 1), (135, 1, -1)])
-def get_u(theta, windspeed):
+@pytest.mark.parametrize("theta,windspeed,u_res", [
+    (0, 1, 0.0),            # -sin(0) = 0
+    (90, 1, -1.0),          # -sin(90) = -1
+    (180, 1, 0.0),          # -sin(180) = 0
+    (270, 1, 1.0),          # -sin(270) = 1
+    (45, 1, -SQRT2_2),      # -sin(45) = -sqrt(2)/2
+    (135, 1, -SQRT2_2),     # -sin(135) = -sqrt(2)/2
+    (225, 1, SQRT2_2),      # -sin(225) = sqrt(2)/2
+    (315, 1, SQRT2_2),      # -sin(315) = sqrt(2)/2
+])
+def test_get_u(theta, windspeed, u_res):
     u_test = WeatherCond.get_u(theta, windspeed)
 
-    assert u_test == pytest.approx(u_test)
+    assert u_test == pytest.approx(u_res)
 
 
-@pytest.mark.parametrize("theta,windspeed,u_res", [(45, 1, -1), (315, 1, -1), (225, 1, 1), (135, 1, 1)])
-def get_v(theta, windspeed):
+@pytest.mark.parametrize("theta,windspeed,v_res", [
+    (0, 1, -1.0),           # -cos(0) = -1
+    (90, 1, 0.0),           # -cos(90) = 0
+    (180, 1, 1.0),          # -cos(180) = 1
+    (270, 1, 0.0),          # -cos(270) = 0
+    (45, 1, -SQRT2_2),      # -cos(45) = -sqrt(2)/2
+    (135, 1, SQRT2_2),      # -cos(135) = sqrt(2)/2
+    (225, 1, SQRT2_2),      # -cos(225) = sqrt(2)/2
+    (315, 1, -SQRT2_2),     # -cos(315) = -sqrt(2)/2
+])
+def test_get_v(theta, windspeed, v_res):
     v_test = WeatherCond.get_v(theta, windspeed)
 
-    assert v_test == pytest.approx(v_test)
+    assert v_test == pytest.approx(v_res)
+
+
+@pytest.mark.parametrize("theta,windspeed", [
+    (0, 1), (45, 1), (90, 1), (135, 1),
+    (180, 1), (225, 1), (270, 1), (315, 1),
+    (60, 5), (120, 0.5),
+])
+def test_uv_magnitude_equals_windspeed(theta, windspeed):
+    u = WeatherCond.get_u(theta, windspeed)
+    v = WeatherCond.get_v(theta, windspeed)
+
+    assert math.sqrt(u**2 + v**2) == pytest.approx(abs(windspeed))
+
+
+@pytest.mark.parametrize("theta,windspeed", [
+    (0, 1), (45, 1), (90, 1), (135, 1),
+    (180, 1), (225, 1), (270, 1), (315, 1),
+    (60, 3),
+])
+def test_uv_roundtrip_recovers_theta(theta, windspeed):
+    u = WeatherCond.get_u(theta, windspeed)
+    v = WeatherCond.get_v(theta, windspeed)
+
+    assert WeatherCond.get_theta_from_uv(u, v) == pytest.approx(theta)

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -15,14 +15,14 @@ def test_theta_from_uv(u, v, theta_res):
 
 
 @pytest.mark.parametrize("theta,windspeed,u_res", [
-    (0, 1, 0.0),            # -sin(0) = 0
-    (90, 1, -1.0),          # -sin(90) = -1
-    (180, 1, 0.0),          # -sin(180) = 0
-    (270, 1, 1.0),          # -sin(270) = 1
-    (45, 1, -SQRT2_2),      # -sin(45) = -sqrt(2)/2
-    (135, 1, -SQRT2_2),     # -sin(135) = -sqrt(2)/2
-    (225, 1, SQRT2_2),      # -sin(225) = sqrt(2)/2
-    (315, 1, SQRT2_2),      # -sin(315) = sqrt(2)/2
+    (0, 1, 0.0),
+    (90, 1, -1.0),
+    (180, 1, 0.0),
+    (270, 1, 1.0),
+    (45, 1, -SQRT2_2),
+    (135, 1, -SQRT2_2),
+    (225, 1, SQRT2_2),
+    (315, 1, SQRT2_2),
 ])
 def test_get_u(theta, windspeed, u_res):
     u_test = WeatherCond.get_u(theta, windspeed)
@@ -31,14 +31,14 @@ def test_get_u(theta, windspeed, u_res):
 
 
 @pytest.mark.parametrize("theta,windspeed,v_res", [
-    (0, 1, -1.0),           # -cos(0) = -1
-    (90, 1, 0.0),           # -cos(90) = 0
-    (180, 1, 1.0),          # -cos(180) = 1
-    (270, 1, 0.0),          # -cos(270) = 0
-    (45, 1, -SQRT2_2),      # -cos(45) = -sqrt(2)/2
-    (135, 1, SQRT2_2),      # -cos(135) = sqrt(2)/2
-    (225, 1, SQRT2_2),      # -cos(225) = sqrt(2)/2
-    (315, 1, -SQRT2_2),     # -cos(315) = -sqrt(2)/2
+    (0, 1, -1.0),
+    (90, 1, 0.0),
+    (180, 1, 1.0),
+    (270, 1, 0.0),
+    (45, 1, -SQRT2_2),
+    (135, 1, SQRT2_2),
+    (225, 1, SQRT2_2),
+    (315, 1, -SQRT2_2),
 ])
 def test_get_v(theta, windspeed, v_res):
     v_test = WeatherCond.get_v(theta, windspeed)


### PR DESCRIPTION
# Related Issue / Discussion:

Fixes Issue #161 

# Changes:

- **Modified** test_weather.py

# Further Details:

## Summary:

`get_u()` and `get_v()` in test_weather.py had 5 compounding defects that made them dead code:

1. Missing `test_` prefix - pytest never collected them
2. `@parametrize` declared 3 params but signatures accepted 2
3. Assertions compared results to themselves (`u_test == pytest.approx(u_test)`)
4. Expected values were wrong (`-1` instead of `-√2/2` for `sin(45°)`)
5. `get_v`'s parametrize string said `u_res` instead of `v_res`

**Before:** 4 tests collected, `get_u`/`get_v` never executed.
**After:** 39 tests collected, all passing. Added cardinal-direction cases (0°, 90°, 180°, 270°) with textbook-exact values, magnitude invariant tests (`√(u²+v²) = |windspeed|`), and round-trip consistency tests (`get_theta_from_uv(get_u(θ), get_v(θ)) == θ`).

No production code changed.

## Dependencies:

None


# PR Checklist:

In the context of this PR, I:
- [x] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [ ] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution

Please consider that PRs which do not meet the requirements specified in the checklist will not be evaluated. Also, PRs with no activities will be closed after a reasonable amount of time.

@MartinPontius @kdemmich 