### PR TITLE
fix(test): correct implicit string concatenation in test_ship.py message arrays

### DIFF
--- a/tests/test_ship.py
+++ b/tests/test_ship.py
@@ -39,7 +39,7 @@ class TestShip:
         salinity = np.array([6.4, 6.5, 6.41, 6.42])
         water_temperature = np.array([6.7, 6.8, 6.71, 6.72])
         status = np.array([1, 2, 2, 3])
-        message = np.array(['OK', 'OK', 'Error' 'OK'])
+        message = np.array(['OK', 'OK', 'Error', 'OK'])
 
         sp = ShipParams(fuel_rate=fuel, power=power, rpm=rpm, speed=speed, r_wind=rwind, r_calm=rcalm, r_waves=rwaves,
                         r_shallow=rshallow, r_roughness=rroughness, wave_height=wave_height,
@@ -105,7 +105,7 @@ class TestShip:
         salinity = np.array([6.4, 6.5, 6.41, 6.42])
         water_temperature = np.array([6.7, 6.8, 6.71, 6.72])
         status = np.array([1, 2, 2, 3])
-        message = np.array(['OK', 'OK', 'Error' 'OK'])
+        message = np.array(['OK', 'OK', 'Error', 'OK'])
 
         sp = ShipParams(fuel_rate=fuel, power=power, rpm=rpm, speed=speed,
                         r_wind=rwind, r_calm=rcalm, r_waves=rwaves,


### PR DESCRIPTION
# Related Issue / Discussion:

Fixes #162 

# Changes:

- **Modified** `tests/test_ship.py` - added missing comma in `message` array literal (2 occurrences)

# Further Details:

## Summary:

In both `test_shipparams_get_element` and `test_shipparams_get_single`, the `message` array was defined as:

```python
message = np.array(['OK', 'OK', 'Error' 'OK'])
```

Python's implicit string concatenation silently merged `'Error'` and `'OK'` into `'ErrorOK'`, producing a 3-element array instead of the intended 4-element array. The tests still passed because the corrupted value round-tripped unchanged through `ShipParams`, masking the defect.

This fix adds the missing comma to restore `['OK', 'OK', 'Error', 'OK']` in both locations.

## Dependencies:

None.

# PR Checklist:

- [x] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [ ] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT's guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution
