### PR TITLE
Fix: fail when optimiser returns no feasible solution

### DIFF
--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -157,6 +157,21 @@ class Genetic(RoutingAlg):
 
         super().terminate()
 
+        if res is None or res.F is None or res.X is None:
+            raise RuntimeError(
+                "Genetic optimization produced no feasible solution "
+                "(empty result: res.F/res.X is None). "
+                "This typically means all candidate routes violated constraints. "
+                "Try relaxing constraints (e.g., disable `water_depth` and/or `via_waypoints` temporarily), "
+                "reducing the bbox/time window, or verifying weather/depth inputs."
+            )
+
+        if np.size(res.F) == 0 or np.size(res.X) == 0:
+            raise RuntimeError(
+                "Genetic optimization produced no feasible solution (empty result array). "
+                "This typically means all candidate routes violated constraints."
+            )
+
         best_index = res.F.argmin()
         # ensure res.X is of shape (n_sol, n_var)
         best_route = np.atleast_2d(res.X)[best_index, 0]

--- a/tests/test_genetic_termination.py
+++ b/tests/test_genetic_termination.py
@@ -1,0 +1,15 @@
+import pytest
+
+from WeatherRoutingTool.algorithms.genetic import Genetic
+
+
+class _EmptyResult:
+    F = None
+    X = None
+
+
+def test_genetic_terminate_raises_on_empty_result():
+    genetic = Genetic.__new__(Genetic)
+
+    with pytest.raises(RuntimeError, match=r"no feasible solution"):
+        genetic.terminate(_EmptyResult(), problem=None)


### PR DESCRIPTION
# Related Issue / Discussion:
This PR addresses [https://github.com/52North/WeatherRoutingTool/issues/164](url)
Relates to #29 (closed)
Fixes Issue #164 

# Changes: 
Please list the central functionalities that have been changed:

- **Modified**: Guard Genetic.terminate() against empty/ None optimisation results and raise a descriptive error that is causing the crash
- **New**: test_genetic_termination.py is a regression test that asserts Genetic.terminate() fails fast with a clear RuntimeError when the result is empty

## Summary:
Under certain condition/ constraints (e.g. water_depth), the genetic optimiser can end up with no feasible solution. In that case, the result res.F/ res.X are empty or None.

 **Behavior before**
Genetic.terminate() unconditionally called res.F.argmin(), which could crash with AttributeError as res.F/ res.X were None. This hides the real cause of the error.

 **Behavior after**
Genetic.terminate() detects None in res.F/ res.X and raises a clear RuntimeError explaining no feasible route found and suggesting to relax constraints.

## Dependencies:
No new runtime dependencies.

# PR Checklist:

In the context of this PR, I:
- [ ] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [x] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [ ] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution