### PR TITLE
fix: clamp lower bound of arcsin argument in get_apparent_wind() to prevent silent NaN

### DIFF
--- a/WeatherRoutingTool/ship/direct_power_boat.py
+++ b/WeatherRoutingTool/ship/direct_power_boat.py
@@ -230,12 +230,15 @@ class DirectPowerBoat(Boat):
             arg_arcsin = true_wind_speed[iang] * np.sin(np.radians(true_wind_angle[iang])) / apparent_wind_speed[
                 iang] * u.radian
 
-            # catch it if argument of arcsin is > 1 due to rounding issues but make sure to apply this only for
+            # catch it if argument of arcsin is > 1 and arcsin is < -1 due to rounding issues but make sure to apply this only for
             # rounding issues
             diff_to_one = arg_arcsin - 1 * u.radian
             if diff_to_one > 0:
                 assert diff_to_one < 0.000001 * u.radian
                 arg_arcsin = 1 * u.radian
+            elif (diff_to_minus_one := arg_arcsin + 1 * u.radian) < 0:
+                assert abs(diff_to_minus_one) < 0.000001 * u.radian
+                arg_arcsin = -1 * u.radian
 
             if apparent_wind_speed[iang] > 0:
                 apparent_wind_angle[iang] = np.arcsin(arg_arcsin.value) * u.radian


### PR DESCRIPTION
# Related Issue / Discussion:
Fixes Issue #170

# Changes:
- **Modified** `direct_power_boat.py` — added lower-bound clamp for `arg_arcsin` 
in `get_apparent_wind()` (lines 235–241)

# Further Details:
## Summary:
The `get_apparent_wind()` method computes `arg_arcsin` as the argument for `np.arcsin()`,
which requires its input to be within [-1, 1]. Due to floating-point rounding, `arg_arcsin`
can produce slightly below -1 (e.g. -1.0000000001).
To rectify this error , the values of arg_arcsin are clamped back to the bound.

**Before:** Only the upper bound (`arg_arcsin > 1`) was clamped. The lower bound 
(`arg_arcsin < -1`) was unhandled, causing `np.arcsin()` to silently return `NaN`, 
corrupting apparent wind angle, power, and fuel calculations.

**After:** A symmetric `elif` branch now clamps the lower bound to `-1` when the 
violation is within rounding tolerance (< 0.000001), consistent with the existing 
upper-bound logic.

## Dependencies:
No new dependencies required.

# PR Checklist:
In the context of this PR, I:
- [ ] have (already previously) filled the 52North Contributor License Agreement
      and received positive feedback on this matter
- [x] have filled the 52North Contributor License Agreement 
      and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework 
      (WeatherRoutingTool/tests) that allow the simple testing of the 
      new/modified functionalities. All (previous and new) unit tests 
      execute without new error messages.
- [x] ensure that the code formatter runs without errors/warnings
- [x] ensure that my changes follow the WRT's guidelines for contributing 
      at the time of the contribution