### PR TITLE
[test] Add shared pytest fixtures via conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,148 @@
+"""
+Shared pytest fixtures for the WeatherRoutingTool test suite.
+
+Fixtures are organised by scope:
+- ``session``  : expensive objects loaded once per test run (ship/algorithm objects
+                 backed by file I/O or heavy initialisation)
+- ``function`` : lightweight in-memory objects that are recreated for every test
+                 to prevent inter-test state leakage
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+import tests.basic_test_func as basic_test_func
+from WeatherRoutingTool.algorithms.isobased import IsoBased
+from WeatherRoutingTool.algorithms.isofuel import IsoFuel
+from WeatherRoutingTool.config import Config
+from WeatherRoutingTool.ship.direct_power_boat import DirectPowerBoat
+from WeatherRoutingTool.ship.ship_config import ShipConfig
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def test_data_dir() -> str:
+    """Absolute path to the ``tests/data/`` directory."""
+    return os.path.join(os.path.dirname(__file__), "data")
+
+
+@pytest.fixture(scope="session")
+def tests_config_path() -> Path:
+    """Path to the main test configuration file ``tests/config.tests.json``."""
+    return Path(__file__).parent / "config.tests.json"
+
+
+# ---------------------------------------------------------------------------
+# Config fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def wrt_config(tests_config_path) -> Config:
+    """
+    ``Config`` object loaded from ``config.tests.json``.
+
+    Session-scoped because the config file never changes during a test run.
+    """
+    return Config.assign_config(path=tests_config_path)
+
+
+@pytest.fixture(scope="session")
+def ship_config(tests_config_path) -> ShipConfig:
+    """
+    ``ShipConfig`` object loaded from ``config.tests.json``.
+
+    Session-scoped because the config file never changes during a test run.
+    """
+    return ShipConfig.assign_config(path=tests_config_path)
+
+
+# ---------------------------------------------------------------------------
+# Ship fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def simpleship() -> DirectPowerBoat:
+    """
+    ``DirectPowerBoat`` whose ship geometry is **auto-calculated** from the
+    mandatory parameters only (hs1, ls1, … are approximated internally).
+
+    Use this fixture whenever the test only cares about power / wind
+    calculations and does not need to verify the geometry itself.
+    """
+    return basic_test_func.create_dummy_Direct_Power_Ship("simpleship")
+
+
+@pytest.fixture(scope="session")
+def manualship() -> DirectPowerBoat:
+    """
+    ``DirectPowerBoat`` with all ship geometry parameters supplied manually.
+
+    Use this fixture when the test needs to verify Fujiwara wind-resistance
+    coefficients or geometry-dependent behaviour.
+    """
+    return basic_test_func.create_dummy_Direct_Power_Ship("manualship")
+
+
+@pytest.fixture
+def base_ship_config_dict() -> dict:
+    """
+    Minimal valid ship-configuration dictionary (simpleship parameters).
+
+    Function-scoped so that each test receives a fresh copy it can mutate
+    freely without affecting other tests.
+    """
+    return {
+        "BOAT_BREADTH": 32,
+        "BOAT_FUEL_RATE": 167,
+        "BOAT_HBR": 30,
+        "BOAT_LENGTH": 180,
+        "BOAT_SMCR_POWER": 6502,
+        "BOAT_SMCR_SPEED": 6,
+        "BOAT_SPEED": 6,
+        "WEATHER_DATA": "abc",
+    }
+
+
+@pytest.fixture
+def simpleship_from_dict(base_ship_config_dict) -> DirectPowerBoat:
+    """
+    ``DirectPowerBoat`` constructed from a plain dictionary (no JSON file
+    required).  Useful for testing ``ShipConfig.assign_config`` paths and
+    for tests that need to vary individual config values.
+    """
+    ship_config = ShipConfig.assign_config(
+        init_mode="from_dict", config_dict=base_ship_config_dict
+    )
+    boat = DirectPowerBoat(ship_config)
+    boat.load_data()
+    return boat
+
+
+# ---------------------------------------------------------------------------
+# Routing algorithm fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def isofuel_algorithm() -> IsoFuel:
+    """
+    ``IsoFuel`` routing algorithm object initialised from ``config.tests.json``.
+
+    Session-scoped because algorithm construction is expensive and the object
+    is treated as read-only by the tests that use it.
+    """
+    return basic_test_func.create_dummy_IsoFuel_object()
+
+
+@pytest.fixture(scope="session")
+def isobased_algorithm() -> IsoBased:
+    """
+    ``IsoBased`` routing algorithm object initialised from ``config.tests.json``.
+
+    Session-scoped for the same reason as ``isofuel_algorithm``.
+    """
+    return basic_test_func.create_dummy_IsoBased_object()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,3 @@
-"""
-Shared pytest fixtures for the WeatherRoutingTool test suite.
-
-Fixtures are organised by scope:
-- ``session``  : expensive objects loaded once per test run (ship/algorithm objects
-                 backed by file I/O or heavy initialisation)
-- ``function`` : lightweight in-memory objects that are recreated for every test
-                 to prevent inter-test state leakage
-"""
-
 import os
 from pathlib import Path
 
@@ -21,81 +11,38 @@ from WeatherRoutingTool.ship.direct_power_boat import DirectPowerBoat
 from WeatherRoutingTool.ship.ship_config import ShipConfig
 
 
-# ---------------------------------------------------------------------------
-# Path helpers
-# ---------------------------------------------------------------------------
-
 @pytest.fixture(scope="session")
 def test_data_dir() -> str:
-    """Absolute path to the ``tests/data/`` directory."""
     return os.path.join(os.path.dirname(__file__), "data")
 
 
 @pytest.fixture(scope="session")
 def tests_config_path() -> Path:
-    """Path to the main test configuration file ``tests/config.tests.json``."""
     return Path(__file__).parent / "config.tests.json"
 
 
-# ---------------------------------------------------------------------------
-# Config fixtures
-# ---------------------------------------------------------------------------
-
 @pytest.fixture(scope="session")
 def wrt_config(tests_config_path) -> Config:
-    """
-    ``Config`` object loaded from ``config.tests.json``.
-
-    Session-scoped because the config file never changes during a test run.
-    """
     return Config.assign_config(path=tests_config_path)
 
 
 @pytest.fixture(scope="session")
 def ship_config(tests_config_path) -> ShipConfig:
-    """
-    ``ShipConfig`` object loaded from ``config.tests.json``.
-
-    Session-scoped because the config file never changes during a test run.
-    """
     return ShipConfig.assign_config(path=tests_config_path)
 
 
-# ---------------------------------------------------------------------------
-# Ship fixtures
-# ---------------------------------------------------------------------------
-
 @pytest.fixture(scope="session")
 def simpleship() -> DirectPowerBoat:
-    """
-    ``DirectPowerBoat`` whose ship geometry is **auto-calculated** from the
-    mandatory parameters only (hs1, ls1, … are approximated internally).
-
-    Use this fixture whenever the test only cares about power / wind
-    calculations and does not need to verify the geometry itself.
-    """
     return basic_test_func.create_dummy_Direct_Power_Ship("simpleship")
 
 
 @pytest.fixture(scope="session")
 def manualship() -> DirectPowerBoat:
-    """
-    ``DirectPowerBoat`` with all ship geometry parameters supplied manually.
-
-    Use this fixture when the test needs to verify Fujiwara wind-resistance
-    coefficients or geometry-dependent behaviour.
-    """
     return basic_test_func.create_dummy_Direct_Power_Ship("manualship")
 
 
 @pytest.fixture
 def base_ship_config_dict() -> dict:
-    """
-    Minimal valid ship-configuration dictionary (simpleship parameters).
-
-    Function-scoped so that each test receives a fresh copy it can mutate
-    freely without affecting other tests.
-    """
     return {
         "BOAT_BREADTH": 32,
         "BOAT_FUEL_RATE": 167,
@@ -110,11 +57,6 @@ def base_ship_config_dict() -> dict:
 
 @pytest.fixture
 def simpleship_from_dict(base_ship_config_dict) -> DirectPowerBoat:
-    """
-    ``DirectPowerBoat`` constructed from a plain dictionary (no JSON file
-    required).  Useful for testing ``ShipConfig.assign_config`` paths and
-    for tests that need to vary individual config values.
-    """
     ship_config = ShipConfig.assign_config(
         init_mode="from_dict", config_dict=base_ship_config_dict
     )
@@ -123,26 +65,11 @@ def simpleship_from_dict(base_ship_config_dict) -> DirectPowerBoat:
     return boat
 
 
-# ---------------------------------------------------------------------------
-# Routing algorithm fixtures
-# ---------------------------------------------------------------------------
-
 @pytest.fixture(scope="session")
 def isofuel_algorithm() -> IsoFuel:
-    """
-    ``IsoFuel`` routing algorithm object initialised from ``config.tests.json``.
-
-    Session-scoped because algorithm construction is expensive and the object
-    is treated as read-only by the tests that use it.
-    """
     return basic_test_func.create_dummy_IsoFuel_object()
 
 
 @pytest.fixture(scope="session")
 def isobased_algorithm() -> IsoBased:
-    """
-    ``IsoBased`` routing algorithm object initialised from ``config.tests.json``.
-
-    Session-scoped for the same reason as ``isofuel_algorithm``.
-    """
     return basic_test_func.create_dummy_IsoBased_object()


### PR DESCRIPTION
# Related Issue / Discussion:
Please delete the option which is not relevant.

Fixes Issue #XX
Relates to discussion [Improve Test Framework – GSoC 2025 Code Challenge]

# Changes:

- **New** `tests/conftest.py` – shared pytest fixtures for the WRT test suite

# Further Details:

## Summary:

**Before:** Every test file independently called `basic_test_func.create_dummy_Direct_Power_Ship()`,
`basic_test_func.create_dummy_IsoFuel_object()`, and repeated path-building
boilerplate (`os.path.dirname(__file__)` + joins) to set up the same objects.
This made tests harder to read and changes to test setup require edits in
multiple files.

**After:** A single `tests/conftest.py` provides session- and function-scoped
fixtures that any test can request by name. Session-scoped fixtures
(`simpleship`, `manualship`, `isofuel_algorithm`, `isobased_algorithm`,
`wrt_config`, `ship_config`) are constructed once per test run, reducing I/O
overhead. Function-scoped fixtures (`base_ship_config_dict`,
`simpleship_from_dict`) are recreated per test to prevent state leakage.

Fixtures added:

| Fixture | Scope | Purpose |
|---|---|---|
| `test_data_dir` | session | Absolute path to `tests/data/` |
| `tests_config_path` | session | Path to `config.tests.json` |
| `wrt_config` | session | `Config` loaded from `config.tests.json` |
| `ship_config` | session | `ShipConfig` loaded from `config.tests.json` |
| `simpleship` | session | `DirectPowerBoat` with auto-calculated geometry |
| `manualship` | session | `DirectPowerBoat` with manual geometry |
| `base_ship_config_dict` | function | Minimal valid ship config as `dict` |
| `simpleship_from_dict` | function | `DirectPowerBoat` built from dict |
| `isofuel_algorithm` | session | `IsoFuel` routing algorithm object |
| `isobased_algorithm` | session | `IsoBased` routing algorithm object |

## Dependencies:

No new dependencies. `conftest.py` uses only packages already listed in
`requirements.test.txt` (`pytest`) and the existing `tests/basic_test_func.py`
helper module.


# Changes: 
Please list the central functionalities that have been changed:

- **New** class / file / …
- **Modified** class / file / …


# Further Details:

## Summary:

Please mention the relevant motivation and context of your changes and shortly describe the behaviour before and after your modifications.

## Dependencies:

Please list new dependencies that are required for this modification.


# PR Checklist:

In the context of this PR, I:
- [ ] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [ ] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [ ] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution

Please consider that PRs which do not meet the requirements specified in the checklist will not be evaluated. Also, PRs with no activities will be closed after a reasonable amount of time.
