### PR TITLE
[test] Add unit tests for Map utility class

### DIFF
--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -1,0 +1,74 @@
+import pytest
+
+from WeatherRoutingTool.utils.maps import Map
+
+
+@pytest.fixture
+def basic_map():
+    return Map(50.0, 5.0, 55.0, 15.0)
+
+
+class TestMapInit:
+    def test_attributes_set(self, basic_map):
+        assert basic_map.lat1 == 50.0
+        assert basic_map.lon1 == 5.0
+        assert basic_map.lat2 == 55.0
+        assert basic_map.lon2 == 15.0
+
+    def test_values_stored_as_float(self):
+        m = Map(10, 20, 30, 40)
+        assert isinstance(m.lat1, float)
+        assert isinstance(m.lon1, float)
+        assert isinstance(m.lat2, float)
+        assert isinstance(m.lon2, float)
+
+    def test_negative_coords(self):
+        m = Map(-33.9, -70.6, -30.0, -65.0)
+        assert m.lat1 == -33.9
+        assert m.lon1 == -70.6
+
+
+class TestExtendVariable:
+    def test_min_subtracts(self, basic_map):
+        assert basic_map.extend_variable(10.0, "min", 2) == 8.0
+
+    def test_max_adds(self, basic_map):
+        assert basic_map.extend_variable(10.0, "max", 2) == 12.0
+
+    def test_invalid_type_raises(self, basic_map):
+        with pytest.raises(ValueError):
+            basic_map.extend_variable(10.0, "center", 2)
+
+    def test_zero_width(self, basic_map):
+        assert basic_map.extend_variable(5.0, "min", 0) == 5.0
+        assert basic_map.extend_variable(5.0, "max", 0) == 5.0
+
+
+class TestGetWideenedMap:
+    def test_returns_map_instance(self, basic_map):
+        assert isinstance(basic_map.get_widened_map(1), Map)
+
+    def test_widens_by_width(self, basic_map):
+        widened = basic_map.get_widened_map(2)
+        assert widened.lat1 == 48.0
+        assert widened.lon1 == 3.0
+        assert widened.lat2 == 57.0
+        assert widened.lon2 == 17.0
+
+    def test_zero_width_unchanged(self, basic_map):
+        widened = basic_map.get_widened_map(0)
+        assert widened.lat1 == basic_map.lat1
+        assert widened.lon1 == basic_map.lon1
+        assert widened.lat2 == basic_map.lat2
+        assert widened.lon2 == basic_map.lon2
+
+
+class TestGetVarTuple:
+    def test_returns_tuple(self, basic_map):
+        assert isinstance(basic_map.get_var_tuple(), tuple)
+
+    def test_correct_order(self, basic_map):
+        assert basic_map.get_var_tuple() == (50.0, 55.0, 5.0, 15.0)
+
+    def test_length(self, basic_map):
+        assert len(basic_map.get_var_tuple()) == 4


### PR DESCRIPTION
# Related Issue / Discussion:
Please delete the option which is not relevant.

Fixes Issue #XX

- Before: `WeatherRoutingTool/utils/maps.py` had zero test coverage.

- After: 13 unit tests covering all methods of the `Map` class grouped
into pytest classes, achieving 100% line coverage (25/25 statements).

Relates to discussion [link]

# Changes: 

Please list the central functionalities that have been changed:


<img width="1511" height="730" alt="Screenshot From 2026-03-18 19-37-52" src="https://github.com/user-attachments/assets/4d2d59f5-ac86-4892-9129-609bb096b9a8" />


# Further Details:

## Summary:

Methods covered:

- `__init__` – attribute assignment and float casting
- `extend_variable` – min/max modes, invalid type error, zero width
- `get_widened_map` – return type, correct widening, zero width passthrough
- `get_var_tuple` – return type, correct order, length
## Dependencies:

Please list new dependencies that are required for this modification.


# PR Checklist:

In the context of this PR, I:
- [ ] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [ ] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [ ] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution

Please consider that PRs which do not meet the requirements specified in the checklist will not be evaluated. Also, PRs with no activities will be closed after a reasonable amount of time.
