### PR TITLE
Fix arcsin lower bound clamp and test data typo

### DIFF
--- a/WeatherRoutingTool/ship/direct_power_boat.py
+++ b/WeatherRoutingTool/ship/direct_power_boat.py
@@ -230,12 +230,16 @@ class DirectPowerBoat(Boat):
             arg_arcsin = true_wind_speed[iang] * np.sin(np.radians(true_wind_angle[iang])) / apparent_wind_speed[
                 iang] * u.radian
 
-            # catch it if argument of arcsin is > 1 due to rounding issues but make sure to apply this only for
-            # rounding issues
+            # clamp arcsin argument to [-1, 1] to handle floating-point rounding
             diff_to_one = arg_arcsin - 1 * u.radian
             if diff_to_one > 0:
                 assert diff_to_one < 0.000001 * u.radian
                 arg_arcsin = 1 * u.radian
+
+            diff_to_neg_one = arg_arcsin + 1 * u.radian
+            if diff_to_neg_one < 0:
+                assert diff_to_neg_one > -0.000001 * u.radian
+                arg_arcsin = -1 * u.radian
 
             if apparent_wind_speed[iang] > 0:
                 apparent_wind_angle[iang] = np.arcsin(arg_arcsin.value) * u.radian

--- a/tests/test_ship.py
+++ b/tests/test_ship.py
@@ -39,7 +39,7 @@ class TestShip:
         salinity = np.array([6.4, 6.5, 6.41, 6.42])
         water_temperature = np.array([6.7, 6.8, 6.71, 6.72])
         status = np.array([1, 2, 2, 3])
-        message = np.array(['OK', 'OK', 'Error' 'OK'])
+        message = np.array(['OK', 'OK', 'Error', 'OK'])
 
         sp = ShipParams(fuel_rate=fuel, power=power, rpm=rpm, speed=speed, r_wind=rwind, r_calm=rcalm, r_waves=rwaves,
                         r_shallow=rshallow, r_roughness=rroughness, wave_height=wave_height,
@@ -105,7 +105,7 @@ class TestShip:
         salinity = np.array([6.4, 6.5, 6.41, 6.42])
         water_temperature = np.array([6.7, 6.8, 6.71, 6.72])
         status = np.array([1, 2, 2, 3])
-        message = np.array(['OK', 'OK', 'Error' 'OK'])
+        message = np.array(['OK', 'OK', 'Error', 'OK'])
 
         sp = ShipParams(fuel_rate=fuel, power=power, rpm=rpm, speed=speed,
                         r_wind=rwind, r_calm=rcalm, r_waves=rwaves,


### PR DESCRIPTION
Found two issues while reading through the code:

`get_apparent_wind()` only clamps the upper bound of the arcsin argument but not the lower bound. When floating-point rounding pushes it below -1, `np.arcsin()` silently returns NaN which corrupts the whole route calculation. Added the missing lower bound check symmetrically to the existing upper bound one.(fixes #170)

`test_ship.py` has `'Error' 'OK'` without a comma — Python concatenates them into `'ErrorOK'`, so the array ends up with 3 elements instead of 4. Tests still passed because they compare the same malformed data on both sides.(fixes #162)

I also emailed gsoc@52north.org about GSoC 2026 (knqzx0@gmail.com)