### PR TITLE
Fix inconsistent coordinate ordering and rename reserved keyword in M…

### DIFF
--- a/WeatherRoutingTool/utils/maps.py
+++ b/WeatherRoutingTool/utils/maps.py
@@ -10,14 +10,13 @@ class Map:
         self.lat2 = float(lat2)
         self.lon2 = float(lon2)
 
-    def extend_variable(self, var, type, width):
-        if type == 'min':
-            var = var - width
-        elif type == 'max':
-            var = var + width
+    def extend_variable(self, var, mode, width):
+        if mode == 'min':
+            return var - width
+        elif mode == 'max':
+            return var + width
         else:
             raise ValueError('Only min and max are accepted!')
-        return var
 
     def get_widened_map(self, width):
         lat1 = self.extend_variable(self.lat1, 'min', width)
@@ -27,4 +26,4 @@ class Map:
         return Map(lat1, lon1, lat2, lon2)
 
     def get_var_tuple(self):
-        return (self.lat1, self.lat2, self.lon1, self.lon2)
+        return (self.lat1, self.lon1, self.lat2, self.lon2)


### PR DESCRIPTION
…ap class

This update fixes two issues in the Map class:

Inconsistent coordinate ordering
The constructor initializes coordinates in the order (lat1, lon1, lat2, lon2), but get_var_tuple() returned them as (lat1, lat2, lon1, lon2). This inconsistency could lead to incorrect usage of map bounds. The tuple order has been corrected to match the constructor. Use of reserved keyword (type)
The parameter type in the extend_variable method shadows Python’s built-in type. It has been renamed to mode to improve code clarity and avoid potential issues.

These changes improve code consistency, readability, and maintainability without altering the core functionality.


# Related Issue / Discussion:
Please delete the option which is not relevant.

Fixes Issue #XX

Relates to discussion [link]

# Changes: 
Please list the central functionalities that have been changed:

- **New** class / file / …
- **Modified** class / file / …


# Further Details:

## Summary:

Please mention the relevant motivation and context of your changes and shortly describe the behaviour before and after your modifications.

## Dependencies:

Please list new dependencies that are required for this modification.


# PR Checklist:

In the context of this PR, I:
- [ ] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [ ] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [ ] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [ ] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [ ] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution

Please consider that PRs which do not meet the requirements specified in the checklist will not be evaluated. Also, PRs with no activities will be closed after a reasonable amount of time.
