### PR TITLE
Add pytest unit/integration markers and test-running docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,27 @@
 Contributions are always welcome. Before creating [Pull Requests](https://github.com/52North/WeatherRoutingTool/pulls) or commenting [Issues](https://github.com/52North/WeatherRoutingTool/issues) please carefully read the [Contributing](https://52north.github.io/WeatherRoutingTool/source/guidelines/contribution_guidelines.html) section in our documentation.
 
 Please do not ask if you can work on an issue. Just re-read our documentation and remember that contributions are welcome! Also be aware that we do not assign issues to contributors we have not worked with yet. If this applies to you please do not ask to be assigned. 
+
+## Running tests
+
+The test suite uses pytest markers to separate fast unit tests from broader integration tests and optional/manual tests.
+
+### Unit tests
+```bash
+./.venv/bin/pytest -m "unit" -q
+```
+
+### Integration tests
+```bash
+./.venv/bin/pytest -m "integration and not manual and not maripower" -q
+```
+
+### Manual tests
+```bash
+./.venv/bin/pytest -m "manual" -q
+```
+
+### Maripower tests
+```bash
+./.venv/bin/pytest -m "maripower" -q
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,11 +1,9 @@
 [pytest]
 
-markers = 
+markers =
+    unit: fast tests for isolated functions/classes
+    integration: tests using configs, datasets, or multiple components
     genetic: tests for genetic algorithm
     maripower: tests that need maripower support
     manual: tests that produce figures as output
 addopts = -ra --tb=short --strict-markers
-
-
-
-	

--- a/tests/test_direct_power_method.py
+++ b/tests/test_direct_power_method.py
@@ -22,6 +22,8 @@ try:
 except ModuleNotFoundError:
     pass  # maripower installation is optional
 
+pytestmark = pytest.mark.integration
+
 
 class TestDPM:
     '''

--- a/tests/test_genetic.py
+++ b/tests/test_genetic.py
@@ -22,6 +22,8 @@ from WeatherRoutingTool.algorithms.genetic.repair import ConstraintViolationRepa
 from WeatherRoutingTool.ship.ship_config import ShipConfig
 from WeatherRoutingTool.utils.maps import Map
 
+pytestmark = pytest.mark.integration
+
 
 def test_isofuelpatcher_singleton():
     dirname = os.path.dirname(__file__)

--- a/tests/test_maripower_tanker.py
+++ b/tests/test_maripower_tanker.py
@@ -22,6 +22,8 @@ try:
 except ModuleNotFoundError:
     pass  # maripower installation is optional
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.skip(reason="maripower needs update of requirements.")
 # @pytest.mark.skipif(not have_maripower, reason="maripower is not installed")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,8 @@ import WeatherRoutingTool.utils.unit_conversion as unit
 import WeatherRoutingTool.algorithms.genetic.utils as gen_utils
 from WeatherRoutingTool.utils.maps import Map
 
+pytestmark = pytest.mark.unit
+
 
 def test_get_angle_bins_2greater360():
     min_alpha = 380 * u.degree

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -2,6 +2,8 @@ import pytest
 
 from WeatherRoutingTool.weather import WeatherCond
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.parametrize("u,v,theta_res", [(-1, -1, 45), (1, -1, 315), (1, 1, 225), (-1, 1, 135)])
 def test_theta_from_uv(u, v, theta_res):


### PR DESCRIPTION
## Summary
This PR adds clearer pytest-based test separation and short contributor docs for running tests by marker.

## Changes
- add `unit` and `integration` markers to `pytest.ini`
- mark:
  - `tests/test_utils.py`
  - `tests/test_weather.py`
  as `unit`
- mark:
  - `tests/test_genetic.py`
  - `tests/test_direct_power_method.py`
  - `tests/test_maripower_tanker.py`
  as `integration`
- add a `Running tests` section to `CONTRIBUTING.md`

## Verification
Ran unit tests:
```bash
./.venv/bin/pytest -m "unit" tests/test_utils.py tests/test_weather.py -q
# Result: 31 passed
```

Ran integration tests:
```bash
./.venv/bin/pytest -m "integration and not manual and not maripower" tests/test_genetic.py tests/test_direct_power_method.py tests/test_maripower_tanker.py -q
# Result:
- 15 passed
- 1 skipped
- 14 deselected
```

## Notes
Manual tests currently depend on a local LaTeX installation and were not part of this PR.