### PR TITLE
Fix weather unit tests for get_u and get_v

### DIFF
--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,24 +1,42 @@
+import math
+
 import pytest
 
 from WeatherRoutingTool.weather import WeatherCond
 
 
+SQRT2_OVER_2 = math.sqrt(2) / 2
+
+
 @pytest.mark.parametrize("u,v,theta_res", [(-1, -1, 45), (1, -1, 315), (1, 1, 225), (-1, 1, 135)])
 def test_theta_from_uv(u, v, theta_res):
     theta_test = WeatherCond.get_theta_from_uv(u, v)
-
     assert theta_test == pytest.approx(theta_res)
 
 
-@pytest.mark.parametrize("theta,windspeed,u_res", [(45, 1, -1), (315, 1, 1), (225, 1, 1), (135, 1, -1)])
-def get_u(theta, windspeed):
+@pytest.mark.parametrize(
+    "theta,windspeed,u_res",
+    [
+        (45, 1, -SQRT2_OVER_2),
+        (315, 1, SQRT2_OVER_2),
+        (225, 1, SQRT2_OVER_2),
+        (135, 1, -SQRT2_OVER_2),
+    ],
+)
+def test_get_u(theta, windspeed, u_res):
     u_test = WeatherCond.get_u(theta, windspeed)
+    assert u_test == pytest.approx(u_res)
 
-    assert u_test == pytest.approx(u_test)
 
-
-@pytest.mark.parametrize("theta,windspeed,u_res", [(45, 1, -1), (315, 1, -1), (225, 1, 1), (135, 1, 1)])
-def get_v(theta, windspeed):
+@pytest.mark.parametrize(
+    "theta,windspeed,v_res",
+    [
+        (45, 1, -SQRT2_OVER_2),
+        (315, 1, -SQRT2_OVER_2),
+        (225, 1, SQRT2_OVER_2),
+        (135, 1, SQRT2_OVER_2),
+    ],
+)
+def test_get_v(theta, windspeed, v_res):
     v_test = WeatherCond.get_v(theta, windspeed)
-
-    assert v_test == pytest.approx(v_test)
+    assert v_test == pytest.approx(v_res)


### PR DESCRIPTION
## Summary
This PR fixes the weather tests for `get_u` and `get_v` so they are actually collected and checked against the correct expected values.

## Changes
- rename `get_u` -> `test_get_u`
- rename `get_v` -> `test_get_v`
- fix assertions so the returned values are compared against expected results
- correct expected component values for 45°, 135°, 225°, and 315° using `sqrt(2) / 2`
- rename the third parametrized expected value from `u_res` to `v_res`

## Verification
Ran:
```bash
./venv/bin/pytest tests/test_weather.py -q
# Result: 12 passed
```
Also ran:
```bash
./.venv/bin/pytest tests/test_utils.py tests/test_weather.py -q
# Result: 39 passed
```

## Notes
Before this change, `get_u` and `get_v` did not start with `test_`, so pytest would not collect them as tests.