### PR TITLE
Mark plot-based genetic tests as manual

### DIFF
--- a/tests/test_genetic.py
+++ b/tests/test_genetic.py
@@ -334,6 +334,7 @@ def test_recalculate_speed_for_route():
     assert np.all((new_route[:, 2] - bs_approx.value) < 0.3)
 
 
+@pytest.mark.manual
 @pytest.mark.skip(reason="Test needs modified route array.")
 def test_single_point_crossover(plt):
     dirname = os.path.dirname(__file__)
@@ -375,6 +376,7 @@ def test_single_point_crossover(plt):
     plt.saveas = "test_single_point_crossoverr.png"
 
 
+@pytest.mark.manual
 def test_speed_crossover(plt):
     dirname = os.path.dirname(__file__)
     configpath = os.path.join(dirname, 'config.isofuel_single_route.json')

--- a/tests/test_genetic_mcdm.py
+++ b/tests/test_genetic_mcdm.py
@@ -4,6 +4,7 @@ import pytest
 from WeatherRoutingTool.algorithms.genetic.mcdm import RMethod
 
 
+@pytest.mark.manual
 @pytest.mark.parametrize("obj_fuel,obj_time", [(1, 1), (1, 2), (2, 1)])
 def test_weight_determination_for_solution_selection(plt, obj_fuel, obj_time):
     fuel_weight = np.random.rand(1, 10000) * 0.1


### PR DESCRIPTION
## Summary
This PR marks plot-producing genetic tests as `manual` so they are separated from the regular automated test runs.

## Changes
- add `@pytest.mark.manual` to `test_single_point_crossover`
- add `@pytest.mark.manual` to `test_speed_crossover`
- add `@pytest.mark.manual` to `test_weight_determination_for_solution_selection`

## Verification
Ran:
```bash
./.venv/bin/pytest -m "manual" tests/test_genetic.py tests/test_genetic_mcdm.py -q
# Result:
- 7 passed
- 1 skipped
- 13 deselected
```
Ran:
```bash
./.venv/bin/pytest -m "not manual" tests/test_genetic.py tests/test_genetic_mcdm.py -q
# Result:
- 13 passed
- 8 deselected
```

## Notes
`test_single_point_crossover` remains skipped with the existing skip reason:
`Test needs modified route array`.