### PR TITLE
rng implementation

### DIFF
--- a/WeatherRoutingTool/algorithms/data_utils.py
+++ b/WeatherRoutingTool/algorithms/data_utils.py
@@ -131,8 +131,8 @@ class GridMixin:
         shuffled_cost[nan_mask] = np.nanmean(cost)
 
         # shuffle first along South-North (latitude), then along West-East (longitude) axis
-        shuffled_cost = genetic_utils.RNG.permutation(shuffled_cost, axis=0)
-        shuffled_cost = genetic_utils.RNG.permutation(shuffled_cost, axis=1)
+        shuffled_cost = self.rng.permutation(shuffled_cost, axis=0)
+        shuffled_cost = self.rng.permutation(shuffled_cost, axis=1)
 
         # assign very high weights to nan values (land pixels)
         shuffled_cost[nan_mask] = 1e20

--- a/WeatherRoutingTool/algorithms/data_utils.py
+++ b/WeatherRoutingTool/algorithms/data_utils.py
@@ -112,7 +112,6 @@ class GridMixin:
     def __init__(self, config: Config, grid, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.grid = grid
-        self.config
         self.rng = genetic_utils.get_rng(config)
 
     def index_to_coords(self, points_as_indices):

--- a/WeatherRoutingTool/algorithms/data_utils.py
+++ b/WeatherRoutingTool/algorithms/data_utils.py
@@ -3,6 +3,7 @@ import xarray as xr
 from astropy import units as u
 from geographiclib.geodesic import Geodesic
 
+from WeatherRoutingTool.algorithms.genetic import utils as genetic_utils
 from WeatherRoutingTool.routeparams import RouteParams
 
 
@@ -130,9 +131,8 @@ class GridMixin:
         shuffled_cost[nan_mask] = np.nanmean(cost)
 
         # shuffle first along South-North (latitude), then along West-East (longitude) axis
-        rng = np.random.default_rng()
-        shuffled_cost = rng.permutation(shuffled_cost, axis=0)
-        shuffled_cost = rng.permutation(shuffled_cost, axis=1)
+        shuffled_cost = genetic_utils.RNG.permutation(shuffled_cost, axis=0)
+        shuffled_cost = genetic_utils.RNG.permutation(shuffled_cost, axis=1)
 
         # assign very high weights to nan values (land pixels)
         shuffled_cost[nan_mask] = 1e20

--- a/WeatherRoutingTool/algorithms/data_utils.py
+++ b/WeatherRoutingTool/algorithms/data_utils.py
@@ -4,6 +4,7 @@ from astropy import units as u
 from geographiclib.geodesic import Geodesic
 
 from WeatherRoutingTool.algorithms.genetic import utils as genetic_utils
+from WeatherRoutingTool.config import Config
 from WeatherRoutingTool.routeparams import RouteParams
 
 
@@ -108,9 +109,11 @@ class GridMixin:
     """
     grid: xr.Dataset
 
-    def __init__(self, grid, *args, **kwargs):
+    def __init__(self, config: Config, grid, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.grid = grid
+        self.config
+        self.rng = genetic_utils.get_rng(config)
 
     def index_to_coords(self, points_as_indices):
         lats = self.grid.coords['latitude'][[lat_index for lat_index, lon_index in points_as_indices]].values.tolist()

--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -80,9 +80,9 @@ class Genetic(RoutingAlg):
 
         plt.set_loglevel(level='warning')  # deactivate matplotlib debug messages if debug mode activated
         seed = None
-        if self.config.GENETIC_FIX_RANDOM_SEED:
+        if self.config.GENETIC_RANDOM_SEED:
             logger.info('Fixing random seed for genetic algorithm.')
-            seed = utils.DEFAULT_RANDOM_SEED
+            seed = self.config.GENETIC_RANDOM_SEED
 
         # inputs
         problem = RoutingProblem(

--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -43,6 +43,7 @@ class Genetic(RoutingAlg):
         super().__init__(config)
 
         self.config = config
+        self.rng = utils.get_rng(config)
 
         # running
         self.figure_path = graphics.get_figure_path()
@@ -82,7 +83,6 @@ class Genetic(RoutingAlg):
         seed = None
         if self.config.GENETIC_FIX_RANDOM_SEED:
             logger.info('Fixing random seed for genetic algorithm.')
-            np.random.seed(1)
             seed = 1
 
         # inputs

--- a/WeatherRoutingTool/algorithms/genetic/__init__.py
+++ b/WeatherRoutingTool/algorithms/genetic/__init__.py
@@ -43,7 +43,6 @@ class Genetic(RoutingAlg):
         super().__init__(config)
 
         self.config = config
-        self.rng = utils.get_rng(config)
 
         # running
         self.figure_path = graphics.get_figure_path()
@@ -83,7 +82,7 @@ class Genetic(RoutingAlg):
         seed = None
         if self.config.GENETIC_FIX_RANDOM_SEED:
             logger.info('Fixing random seed for genetic algorithm.')
-            seed = 1
+            seed = utils.DEFAULT_RANDOM_SEED
 
         # inputs
         problem = RoutingProblem(

--- a/WeatherRoutingTool/algorithms/genetic/crossover.py
+++ b/WeatherRoutingTool/algorithms/genetic/crossover.py
@@ -357,6 +357,7 @@ class CrossoverFactory:
         if config.GENETIC_CROSSOVER_TYPE == "waypoints":
             logger.debug('Setting crossover type of genetic algorithm to "random".')
             return RandomizedCrossoversOrchestrator(
+                config=config,
                 opts=[
                     TwoPointCrossover(
                         config=config,

--- a/WeatherRoutingTool/algorithms/genetic/crossover.py
+++ b/WeatherRoutingTool/algorithms/genetic/crossover.py
@@ -75,7 +75,6 @@ class OffspringRejectionCrossover(CrossoverBase):
             constraints_list: ConstraintsList,
             prob=.5,
             crossover_type="unnamed"
-
     ):
         super().__init__(prob=prob)
 

--- a/WeatherRoutingTool/algorithms/genetic/crossover.py
+++ b/WeatherRoutingTool/algorithms/genetic/crossover.py
@@ -1,5 +1,4 @@
 import logging
-import random
 from copy import deepcopy
 from datetime import datetime
 from math import ceil
@@ -76,6 +75,7 @@ class OffspringRejectionCrossover(CrossoverBase):
             constraints_list: ConstraintsList,
             prob=.5,
             crossover_type="unnamed"
+
     ):
         super().__init__(prob=prob)
 
@@ -86,6 +86,7 @@ class OffspringRejectionCrossover(CrossoverBase):
         self.crossover_type = crossover_type
         self.constraints_rejection = True
         self.config = config
+        self.rng = utils.get_rng(config)
 
         if not (config.GENETIC_REPAIR_TYPE == ["no_repair"]):
             self.constraints_rejection = False
@@ -164,8 +165,8 @@ class SinglePointCrossover(OffspringRejectionCrossover):
         # setup patching
         patchfn = PatchFactory.get_patcher(patch_type=self.patch_type, config=self.config, application="SP crossover")
 
-        p1x = np.random.randint(1, p1.shape[0] - 1)
-        p2x = np.random.randint(1, p2.shape[0] - 1)
+        p1x = self.rng.integers(1, p1.shape[0] - 1)
+        p2x = self.rng.integers(1, p2.shape[0] - 1)
 
         r1 = np.concatenate([
             p1[:p1x],
@@ -195,11 +196,11 @@ class TwoPointCrossover(OffspringRejectionCrossover):
     def crossover(self, p1, p2):
         patchfn = PatchFactory.get_patcher(patch_type=self.patch_type, config=self.config, application="TP crossover")
 
-        p1x1 = np.random.randint(1, p1.shape[0] - 4)
-        p1x2 = p1x1 + np.random.randint(3, p1.shape[0] - p1x1 - 1)
+        p1x1 = self.rng.integers(1, p1.shape[0] - 4)
+        p1x2 = p1x1 + self.rng.integers(3, p1.shape[0] - p1x1 - 1)
 
-        p2x1 = np.random.randint(1, p2.shape[0] - 4)
-        p2x2 = p2x1 + np.random.randint(3, p2.shape[0] - p2x1 - 1)
+        p2x1 = self.rng.integers(1, p2.shape[0] - 4)
+        p2x2 = p2x1 + self.rng.integers(3, p2.shape[0] - p2x1 - 1)
 
         r1 = np.concatenate([
             p1[:p1x1],
@@ -227,13 +228,15 @@ class RandomizedCrossoversOrchestrator(CrossoverBase):
     :type opts: list[Crossover]
     """
 
-    def __init__(self, opts, **kw):
+    def __init__(self, config: Config, opts, **kw):
         super().__init__(**kw)
 
         self.opts = opts
+        self.config = config
+        self.rng = utils.get_rng(config)
 
     def _do(self, problem, X, **kw):
-        opt = self.opts[np.random.randint(0, len(self.opts))]
+        opt = self.opts[self.rng.integers(0, len(self.opts))]
         return opt._do(problem, X, **kw)
 
     def print_crossover_statistics(self):
@@ -272,7 +275,11 @@ class SpeedCrossover(OffspringRejectionCrossover):
                 if d < self.threshold:
                     crossover_candidates.append((m, n))
         # Swap speed values for a subset of candidate points
-        indices = random.sample(range(0, len(crossover_candidates)), ceil(self.percentage * len(crossover_candidates)))
+        indices = self.rng.choice(
+            len(crossover_candidates),
+            size=ceil(self.percentage * len(crossover_candidates)),
+            replace=False,
+        )
         for idx in indices:
             c = crossover_candidates[idx]
             speed1 = o1[c[0], -1]
@@ -304,11 +311,11 @@ class TwoPointCrossoverSpeed(OffspringRejectionCrossover):
         r1 = deepcopy(p1)
         r2 = deepcopy(p2)
 
-        p1x1 = np.random.randint(1, p1.shape[0] - 4)
-        p1x2 = p1x1 + np.random.randint(3, p1.shape[0] - p1x1 - 1)
+        p1x1 = self.rng.integers(1, p1.shape[0] - 4)
+        p1x2 = p1x1 + self.rng.integers(3, p1.shape[0] - p1x1 - 1)
 
-        p2x1 = np.random.randint(1, p2.shape[0] - 4)
-        p2x2 = p2x1 + np.random.randint(3, p2.shape[0] - p2x1 - 1)
+        p2x1 = self.rng.integers(1, p2.shape[0] - 4)
+        p2x2 = p2x1 + self.rng.integers(3, p2.shape[0] - p2x1 - 1)
 
         speed1 = p1[:, -1]
         speed2 = p2[:, -1]
@@ -371,6 +378,7 @@ class CrossoverFactory:
         if config.GENETIC_CROSSOVER_TYPE == "random":
             logger.debug('Setting crossover type of genetic algorithm to "random".')
             return RandomizedCrossoversOrchestrator(
+                config=config,
                 opts=[
                     TwoPointCrossover(
                         config=config,

--- a/WeatherRoutingTool/algorithms/genetic/mutation.py
+++ b/WeatherRoutingTool/algorithms/genetic/mutation.py
@@ -588,8 +588,6 @@ class GaussianSpeedMutation(MutationConstraintRejection):
         self.mu = 0.5 * self.config.BOAT_SPEED_BOUNDARIES[1]
         self.sigma = 1.54
         self.max_acceleration = 1
-        self.config = config
-        self.rng = utils.get_rng(config)
 
     def mutate(self, problem, rt, **kw):
         rt_new = copy.deepcopy(rt)
@@ -607,7 +605,7 @@ class GaussianSpeedMutation(MutationConstraintRejection):
                 new = old_speed
             rt_new[i][2] = new
 
-        rt_new[:, 2] = utils.smoothen_speed(rt_new[:, 2], 1)
+        rt_new[:, 2] = utils.smoothen_speed(rt_new[:, 2], self.max_acceleration)
         return rt_new
 
 
@@ -676,6 +674,7 @@ class MutationFactory:
         if config.GENETIC_MUTATION_TYPE == "speed":
             logger.debug('Setting mutation type of genetic algorithm to "rndm_speed".')
             return RandomMutationsOrchestrator(
+                config,
                 waypoint_opts=None,
                 speed_opts=[
                     # RandomPercentageChangeSpeedMutation(config=config, constraints_list=constraints_list),
@@ -685,6 +684,7 @@ class MutationFactory:
         if config.GENETIC_MUTATION_TYPE == "waypoints":
             logger.debug('Setting mutation type of genetic algorithm to "rndm_waypoints".')
             return RandomMutationsOrchestrator(
+                config,
                 waypoint_opts=[
                     RandomPlateauMutation(config=config, constraints_list=constraints_list),
                     RouteBlendMutation(config=config, constraints_list=constraints_list),

--- a/WeatherRoutingTool/algorithms/genetic/mutation.py
+++ b/WeatherRoutingTool/algorithms/genetic/mutation.py
@@ -585,7 +585,7 @@ class GaussianSpeedMutation(MutationConstraintRejection):
         self.n_updates = n_updates
         # FIXME: these numbers should be carefully evaluated
         # ~99.7 % in interval (0, BOAT_SPEED_MAX)
-        self.mu = 0.5 * self.config.BOAT_SPEED_BOUNDARIES[1]
+        # self.mu = 0.5 * self.config.BOAT_SPEED_BOUNDARIES[1]
         self.sigma = 1.54
         self.max_acceleration = 1
 

--- a/WeatherRoutingTool/algorithms/genetic/mutation.py
+++ b/WeatherRoutingTool/algorithms/genetic/mutation.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import math
 import os
-import random
 from operator import add, sub
 
 import cartopy.crs as ccrs
@@ -73,8 +72,8 @@ class MutationConstraintRejection(Mutation):
 
     def __init__(
             self,
-            mutation_type: str,
             config: Config,
+            mutation_type: str,
             constraints_list: ConstraintsList,
             prob: float = 1.0,
             prob_var: float = None
@@ -101,6 +100,7 @@ class MutationConstraintRejection(Mutation):
         self.nof_mutation_success = 0
         self.constraints_rejection = True
         self.config = config
+        self.rng = utils.get_rng(config)
 
         if not (config.GENETIC_REPAIR_TYPE == ["no_repair"]):
             self.constraints_rejection = False
@@ -172,7 +172,6 @@ class RandomPlateauMutation(MutationConstraintRejection):
     :type patchnf: PatcherBase
     """
 
-    config: Config
     dist: float
     n_updates: int
     plateau_size: int
@@ -202,6 +201,7 @@ class RandomPlateauMutation(MutationConstraintRejection):
             :param plateau_slope: Number of waypoints that form the side of the plateau.
             :type plateau_slope: int
         """
+
         super().__init__(
             mutation_type="RandomPlateauMutation",
             **kw
@@ -286,7 +286,7 @@ class RandomPlateauMutation(MutationConstraintRejection):
 
         for _ in range(0, self.n_updates):
             # obtain indices for plateau generation
-            rindex = np.random.randint(np.ceil(plateau_length / 2), route_length - np.ceil(plateau_length / 2))
+            rindex = self.rng.integers(np.ceil(plateau_length / 2), route_length - np.ceil(plateau_length / 2))
             i_plateau_start = int(rindex - np.ceil((self.plateau_size - 1) / 2))
             i_plateau_end = int(rindex + np.ceil((self.plateau_size - 1) / 2))
             i_slope_start = int(i_plateau_start - self.plateau_slope) + 1
@@ -303,7 +303,7 @@ class RandomPlateauMutation(MutationConstraintRejection):
             # mutate plateau edges by random walk in same direction
             p1_orig = rt[i_plateau_start]
             p2_orig = rt[i_plateau_end]
-            bearing = np.random.randint(0, 360)
+            bearing = self.rng.integers(0, 360)
             rt_new[i_plateau_start] = self.random_walk(
                 point=p1_orig,
                 dist=self.dist,
@@ -447,8 +447,8 @@ class RouteBlendMutation(MutationConstraintRejection):
         if route_length <= self.min_length:
             return rt_new
 
-        start = np.random.randint(0, route_length - self.min_length)
-        length = np.random.randint(self.min_length, min(self.max_length, route_length - start))
+        start = self.rng.integers(0, route_length - self.min_length)
+        length = self.rng.integers(self.min_length, min(self.max_length, route_length - start))
         end = start + length
         n_points = length
 
@@ -522,13 +522,13 @@ class RandomWalkMutation(MutationConstraintRejection):
 
     def mutate(self, problem, rt, **kw):
         for _ in range(self.n_updates):
-            rindex = np.random.randint(1, rt.shape[0] - 1)
+            rindex = self.rng.integers(1, rt.shape[0] - 1)
             p1 = rt[rindex]
 
             p2 = self.random_walk(
                 point=p1,
                 dist=self.dist,
-                bearing=np.random.choice([45, 135, 225, 315]), )
+                bearing=self.rng.choice([45, 135, 225, 315]), )
             rt[rindex] = p2
         return rt
 
@@ -552,13 +552,13 @@ class RandomPercentageChangeSpeedMutation(MutationConstraintRejection):
 
     def mutate(self, problem, rt, **kw):
         try:
-            indices = random.sample(range(0, rt.shape[0] - 1), self.n_updates)
+            indices = self.rng.choice(rt.shape[0] - 1, size=self.n_updates, replace=False)
         except ValueError:
             indices = range(0, rt.shape[0] - 1)
         ops = (add, sub)
         for i in indices:
-            op = random.choice(ops)
-            change_percent = random.uniform(0.0, self.change_percent_max)
+            op = ops[self.rng.integers(0, len(ops))]
+            change_percent = self.rng.uniform(0.0, self.change_percent_max)
             new = op(rt[i][2], change_percent * rt[i][2])
             if new < self.config.BOAT_SPEED_BOUNDARIES[0]:
                 new = self.config.BOAT_SPEED_BOUNDARIES[0]
@@ -575,44 +575,38 @@ class GaussianSpeedMutation(MutationConstraintRejection):
     is half of the maximum boat speed. The standard deviation is 1/6 of the maximum boat speed.
     """
     n_updates: int
-    config: Config
 
-    def __init__(self, n_updates: int = 5, **kw):
+    def __init__(self, config: Config, n_updates: int = 5, **kw):
         super().__init__(
+            config,
             mutation_type="GaussianSpeedMutation",
             **kw
         )
         self.n_updates = n_updates
         # FIXME: these numbers should be carefully evaluated
         # ~99.7 % in interval (0, BOAT_SPEED_MAX)
-        # self.mu = 0.5 * self.config.BOAT_SPEED_BOUNDARIES[1]
-        self.sigma = 1.54
-        self.max_acceleration = 1
-
-        # Fix random seed depending on configuration
-        self.rndm_gen = None
-        if self.config.GENETIC_FIX_RANDOM_SEED:
-            self.rndm_gen = np.random.default_rng(1)
-        else:
-            self.rndm_gen = np.random.default_rng()
+        self.mu = 0.5 * self.config.BOAT_SPEED_BOUNDARIES[1]
+        self.sigma = 1.
+        self.config = config
+        self.rng = utils.get_rng(config)
 
     def mutate(self, problem, rt, **kw):
         rt_new = copy.deepcopy(rt)
         all_inds = np.linspace(start=0, stop=rt.shape[0] - 1, num=rt.shape[0], dtype=int)
         try:
-            indices = np.random.choice(all_inds, self.n_updates)
+            indices = self.rng.choice(all_inds, self.n_updates)
         except ValueError:
             indices = all_inds
         for i in indices:
             old_speed = rt[i][2]
-            new = self.rndm_gen.normal(loc=old_speed, scale=self.sigma)
+            new = self.rng.normal(loc=old_speed, scale=self.sigma)
             if new < self.config.BOAT_SPEED_BOUNDARIES[0]:
                 new = old_speed
             elif new > self.config.BOAT_SPEED_BOUNDARIES[1]:
                 new = old_speed
             rt_new[i][2] = new
 
-        rt_new[:, 2] = utils.smoothen_speed(rt_new[:, 2], self.max_acceleration)
+        rt_new[:, 2] = utils.smoothen_speed(rt_new[:, 2], 1)
         return rt_new
 
 
@@ -625,19 +619,20 @@ class RandomMutationsOrchestrator(MutationBase):
     :param waypoint_opts: List of Mutation classes for mutating waypoints.
     :type waypoint_optsgit s: list[Mutation]
     """
-
-    def __init__(self, speed_opts, waypoint_opts, **kw):
+    def __init__(self, config: Config, speed_opts, waypoint_opts, **kw):
         super().__init__(**kw)
 
         self.speed_opts = speed_opts
         self.waypoint_opts = waypoint_opts
+        self.config = config
+        self.rng = utils.get_rng(config)
 
     def _do(self, problem, X, **kw):
         if self.speed_opts:
-            speed_opt = self.speed_opts[np.random.randint(0, len(self.speed_opts))]
+            speed_opt = self.speed_opts[self.rng.integers(0, len(self.speed_opts))]
             X = speed_opt._do(problem, X, **kw)
         if self.waypoint_opts:
-            waypoint_opt = self.waypoint_opts[np.random.randint(0, len(self.waypoint_opts))]
+            waypoint_opt = self.waypoint_opts[self.rng.integers(0, len(self.waypoint_opts))]
             X = waypoint_opt._do(problem, X, **kw)
         return X
 
@@ -667,6 +662,7 @@ class MutationFactory:
         if config.GENETIC_MUTATION_TYPE == "random":
             logger.debug('Setting mutation type of genetic algorithm to "random".')
             return RandomMutationsOrchestrator(
+                config,
                 waypoint_opts=[
                     RandomPlateauMutation(config=config, constraints_list=constraints_list),
                     RouteBlendMutation(config=config, constraints_list=constraints_list),

--- a/WeatherRoutingTool/algorithms/genetic/mutation.py
+++ b/WeatherRoutingTool/algorithms/genetic/mutation.py
@@ -586,7 +586,8 @@ class GaussianSpeedMutation(MutationConstraintRejection):
         # FIXME: these numbers should be carefully evaluated
         # ~99.7 % in interval (0, BOAT_SPEED_MAX)
         self.mu = 0.5 * self.config.BOAT_SPEED_BOUNDARIES[1]
-        self.sigma = 1.
+        self.sigma = 1.54
+        self.max_acceleration = 1
         self.config = config
         self.rng = utils.get_rng(config)
 

--- a/WeatherRoutingTool/algorithms/genetic/mutation.py
+++ b/WeatherRoutingTool/algorithms/genetic/mutation.py
@@ -623,7 +623,6 @@ class RandomMutationsOrchestrator(MutationBase):
 
         self.speed_opts = speed_opts
         self.waypoint_opts = waypoint_opts
-        self.config = config
         self.rng = utils.get_rng(config)
 
     def _do(self, problem, X, **kw):

--- a/WeatherRoutingTool/algorithms/genetic/population.py
+++ b/WeatherRoutingTool/algorithms/genetic/population.py
@@ -33,6 +33,7 @@ class Population(Sampling):
         self.constraints_list = constraints_list
         self.n_constrained_routes = 0
         self.pop_size = pop_size
+        self.rng = utils.get_rng(config)
 
         self.src: tuple[float, float] = tuple(default_route[:-2])
         self.dst: tuple[float, float] = tuple(default_route[-2:])
@@ -110,8 +111,8 @@ class Population(Sampling):
         rt[:, 2] = np.full(rt[:, 1].shape, bs)
         return rt
 
-    @staticmethod
-    def spread_velocity(min_boat_speed: float, max_boat_speed: float, boat_speed: float, pop_size: float) -> np.ndarray:
+    def spread_velocity(self, min_boat_speed: float, max_boat_speed: float,
+                        boat_speed: float, pop_size: float) -> np.ndarray:
         """
         Calculate velocity spread for individuals in case of pure speed optimisation.
 
@@ -134,7 +135,7 @@ class Population(Sampling):
         :rtype: np.ndarray
         """
         std_dev = (max_boat_speed - min_boat_speed) / 4
-        gaussian_sample = np.random.normal(boat_speed, std_dev, 1000)
+        gaussian_sample = self.rng.normal(boat_speed, std_dev, 1000)
         gaussian_sample[gaussian_sample < min_boat_speed] = np.nan
         gaussian_sample[gaussian_sample > max_boat_speed] = np.nan
         gaussian_sample = gaussian_sample[~np.isnan(gaussian_sample)]

--- a/WeatherRoutingTool/algorithms/genetic/utils.py
+++ b/WeatherRoutingTool/algorithms/genetic/utils.py
@@ -11,8 +11,17 @@ from pymoo.core.duplicate import ElementwiseDuplicateElimination
 import WeatherRoutingTool.utils.graphics as graphics
 from WeatherRoutingTool.constraints.constraints import ConstraintsList
 from WeatherRoutingTool.routeparams import RouteParams
+from WeatherRoutingTool.config import Config
+
 
 logger = logging.getLogger("WRT.genetic")
+
+
+def get_rng(config: Config, seed=1):
+    if config.GENETIC_FIX_RANDOM_SEED:
+        return np.random.default_rng(seed)
+    else:
+        return np.random.default_rng()
 
 
 def gcr_distance(src, dst) -> float:

--- a/WeatherRoutingTool/algorithms/genetic/utils.py
+++ b/WeatherRoutingTool/algorithms/genetic/utils.py
@@ -17,7 +17,17 @@ from WeatherRoutingTool.config import Config
 logger = logging.getLogger("WRT.genetic")
 
 
-def get_rng(config: Config, seed=1):
+def get_rng(config: Config, seed: int = 1) -> np.random.Generator:
+    """Return a NumPy random generator for genetic operations.
+
+    :param config: Application configuration that controls reproducibility.
+    :type config: Config
+    :param seed: Seed to use when deterministic randomness is enabled.
+    :type seed: int
+    :return: A NumPy ``Generator`` instance.
+    :rtype: np.random.Generator
+    """
+
     if config.GENETIC_FIX_RANDOM_SEED:
         return np.random.default_rng(seed)
     else:

--- a/WeatherRoutingTool/algorithms/genetic/utils.py
+++ b/WeatherRoutingTool/algorithms/genetic/utils.py
@@ -15,24 +15,18 @@ from WeatherRoutingTool.config import Config
 
 
 logger = logging.getLogger("WRT.genetic")
-DEFAULT_RANDOM_SEED = 1
 
 
-def get_rng(config: Config, seed: int = DEFAULT_RANDOM_SEED) -> np.random.Generator:
+def get_rng(config: Config) -> np.random.Generator:
     """Return a NumPy random generator for genetic operations.
 
     :param config: Application configuration that controls reproducibility.
     :type config: Config
-    :param seed: Seed to use when deterministic randomness is enabled.
-    :type seed: int
     :return: A NumPy ``Generator`` instance.
     :rtype: np.random.Generator
     """
 
-    if config.GENETIC_FIX_RANDOM_SEED:
-        return np.random.default_rng(seed)
-    else:
-        return np.random.default_rng()
+    return np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
 
 def gcr_distance(src, dst) -> float:

--- a/WeatherRoutingTool/algorithms/genetic/utils.py
+++ b/WeatherRoutingTool/algorithms/genetic/utils.py
@@ -15,9 +15,10 @@ from WeatherRoutingTool.config import Config
 
 
 logger = logging.getLogger("WRT.genetic")
+DEFAULT_RANDOM_SEED = 1
 
 
-def get_rng(config: Config, seed: int = 1) -> np.random.Generator:
+def get_rng(config: Config, seed: int = DEFAULT_RANDOM_SEED) -> np.random.Generator:
     """Return a NumPy random generator for genetic operations.
 
     :param config: Application configuration that controls reproducibility.

--- a/WeatherRoutingTool/config.py
+++ b/WeatherRoutingTool/config.py
@@ -112,7 +112,7 @@ class Config(BaseModel):
     ] = 'random'
     GENETIC_CROSSOVER_TYPE: Literal['random', 'speed', "waypoints"] = 'random'
     GENETIC_CROSSOVER_PATCHER: Literal['gcr', 'isofuel'] = 'isofuel'
-    GENETIC_FIX_RANDOM_SEED: bool = False
+    GENETIC_RANDOM_SEED: int = None
     GENETIC_OBJECTIVES: Dict[str, float] = {"arrival_time": 1.5, "fuel_consumption": 1.5}  # dictionary for configuring
     # the objectives and objective weights
 

--- a/WeatherRoutingTool/execute_routing.py
+++ b/WeatherRoutingTool/execute_routing.py
@@ -74,5 +74,7 @@ def execute_routing(config, ship_config):
         min_fuel_route_postprocessed = postprocessed_route.post_process_route()
         min_fuel_route_postprocessed.write_to_geojson(
             routepath / f"{min_fuel_route_postprocessed.route_type}_postprocessed.geojson")
+
+    print(boat.counter)
     # prof.disable()
     # prof.dump_stats('wrt_run.prof')

--- a/WeatherRoutingTool/execute_routing.py
+++ b/WeatherRoutingTool/execute_routing.py
@@ -75,6 +75,5 @@ def execute_routing(config, ship_config):
         min_fuel_route_postprocessed.write_to_geojson(
             routepath / f"{min_fuel_route_postprocessed.route_type}_postprocessed.geojson")
 
-    print(boat.counter)
     # prof.disable()
     # prof.dump_stats('wrt_run.prof')

--- a/WeatherRoutingTool/ship/ship.py
+++ b/WeatherRoutingTool/ship/ship.py
@@ -26,7 +26,6 @@ class Boat:
         self.time_min_max = [None, None]
         self.lat_min_max = [None, None]
         self.lon_min_max = [None, None]
-        self.counter = 0
 
     def get_required_water_depth(self):
         needs_water_depth = max(self.draught_aft, self.draught_fore) + self.under_keel_clearance
@@ -132,7 +131,6 @@ class Boat:
         if depth:
             ship_var = ship_var.sel(depth=depth, method='nearest', drop=False)
         ship_var = ship_var.fillna(0).to_numpy()
-        self.counter += 1
 
         return ship_var
 

--- a/WeatherRoutingTool/ship/ship.py
+++ b/WeatherRoutingTool/ship/ship.py
@@ -26,6 +26,7 @@ class Boat:
         self.time_min_max = [None, None]
         self.lat_min_max = [None, None]
         self.lon_min_max = [None, None]
+        self.counter = 0
 
     def get_required_water_depth(self):
         needs_water_depth = max(self.draught_aft, self.draught_fore) + self.under_keel_clearance
@@ -131,6 +132,7 @@ class Boat:
         if depth:
             ship_var = ship_var.sel(depth=depth, method='nearest', drop=False)
         ship_var = ship_var.fillna(0).to_numpy()
+        self.counter += 1
 
         return ship_var
 

--- a/tests/test_genetic.py
+++ b/tests/test_genetic.py
@@ -107,7 +107,7 @@ def test_random_plateau_mutation(plt):
     config.GENETIC_RANDOM_SEED = 1
     default_map = Map(32., 15, 36, 29)
     constraint_list = basic_test_func.generate_dummy_constraint_list()
-    np.random.seed(config.GENETIC_RANDOM_SEED)
+    np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
     mt = RandomPlateauMutation(config=config, constraints_list=constraint_list)
     mt.dist = 1e5
@@ -159,7 +159,7 @@ def test_random_plateau_mutation_refusal():
     config.GENETIC_RANDOM_SEED = 1
     constraint_list = basic_test_func.generate_dummy_constraint_list()
 
-    np.random.seed(config.GENETIC_RANDOM_SEED)
+    np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
     mt = RandomPlateauMutation(config=config, constraints_list=constraint_list)
     X = get_dummy_route_input(length="short")
@@ -184,7 +184,7 @@ def test_bezier_curve_mutation(plt):
     config.GENETIC_RANDOM_SEED = 2
     default_map = Map(32., 15, 36, 29)
     constraint_list = basic_test_func.generate_dummy_constraint_list()
-    np.random.seed(config.GENETIC_RANDOM_SEED)
+    np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
     mt = RouteBlendMutation(config=config, constraints_list=constraint_list)
     X = get_dummy_route_input()
@@ -236,7 +236,7 @@ def test_bezier_mutation_refusal():
     config.GENETIC_RANDOM_SEED = 1
     constraint_list = basic_test_func.generate_dummy_constraint_list()
 
-    np.random.seed(config.GENETIC_RANDOM_SEED)
+    np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
     mt = RouteBlendMutation(config=config, constraints_list=constraint_list)
     mt.min_length = 9
@@ -275,7 +275,7 @@ def test_constraint_violation_repair(plt):
     config.GENETIC_RANDOM_SEED = 2
     default_map = Map(32., 15, 36, 29)
     constraint_list = basic_test_func.generate_dummy_constraint_list()
-    np.random.seed(config.GENETIC_RANDOM_SEED)
+    np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
     patchfn = PatchFactory.get_patcher(
         patch_type="isofuel_singleton",
@@ -351,7 +351,7 @@ def test_single_point_crossover(plt):
     constraint_list = basic_test_func.generate_dummy_constraint_list()
     departure_time = datetime(2025, 4, 1, 11, 11)
 
-    np.random.seed(config.GENETIC_RANDOM_SEED)
+    np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
     X = get_dummy_route_input()
     old_route = copy.deepcopy(X)

--- a/tests/test_genetic.py
+++ b/tests/test_genetic.py
@@ -107,7 +107,6 @@ def test_random_plateau_mutation(plt):
     config.GENETIC_RANDOM_SEED = 1
     default_map = Map(32., 15, 36, 29)
     constraint_list = basic_test_func.generate_dummy_constraint_list()
-    np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
     mt = RandomPlateauMutation(config=config, constraints_list=constraint_list)
     mt.dist = 1e5
@@ -159,8 +158,6 @@ def test_random_plateau_mutation_refusal():
     config.GENETIC_RANDOM_SEED = 1
     constraint_list = basic_test_func.generate_dummy_constraint_list()
 
-    np.random.default_rng(config.GENETIC_RANDOM_SEED)
-
     mt = RandomPlateauMutation(config=config, constraints_list=constraint_list)
     X = get_dummy_route_input(length="short")
     old_route = copy.deepcopy(X)
@@ -184,7 +181,6 @@ def test_bezier_curve_mutation(plt):
     config.GENETIC_RANDOM_SEED = 2
     default_map = Map(32., 15, 36, 29)
     constraint_list = basic_test_func.generate_dummy_constraint_list()
-    np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
     mt = RouteBlendMutation(config=config, constraints_list=constraint_list)
     X = get_dummy_route_input()
@@ -236,8 +232,6 @@ def test_bezier_mutation_refusal():
     config.GENETIC_RANDOM_SEED = 1
     constraint_list = basic_test_func.generate_dummy_constraint_list()
 
-    np.random.default_rng(config.GENETIC_RANDOM_SEED)
-
     mt = RouteBlendMutation(config=config, constraints_list=constraint_list)
     mt.min_length = 9
     X = get_dummy_route_input(length="short")
@@ -275,7 +269,6 @@ def test_constraint_violation_repair(plt):
     config.GENETIC_RANDOM_SEED = 2
     default_map = Map(32., 15, 36, 29)
     constraint_list = basic_test_func.generate_dummy_constraint_list()
-    np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
     patchfn = PatchFactory.get_patcher(
         patch_type="isofuel_singleton",
@@ -350,8 +343,6 @@ def test_single_point_crossover(plt):
     input_crs = ccrs.PlateCarree()
     constraint_list = basic_test_func.generate_dummy_constraint_list()
     departure_time = datetime(2025, 4, 1, 11, 11)
-
-    np.random.default_rng(config.GENETIC_RANDOM_SEED)
 
     X = get_dummy_route_input()
     old_route = copy.deepcopy(X)

--- a/tests/test_genetic.py
+++ b/tests/test_genetic.py
@@ -104,9 +104,10 @@ def test_random_plateau_mutation(plt):
     dirname = os.path.dirname(__file__)
     configpath = os.path.join(dirname, 'config.isofuel_single_route.json')
     config = Config.assign_config(Path(configpath))
+    config.GENETIC_RANDOM_SEED = 1
     default_map = Map(32., 15, 36, 29)
     constraint_list = basic_test_func.generate_dummy_constraint_list()
-    np.random.seed(1)
+    np.random.seed(config.GENETIC_RANDOM_SEED)
 
     mt = RandomPlateauMutation(config=config, constraints_list=constraint_list)
     mt.dist = 1e5
@@ -155,9 +156,10 @@ def test_random_plateau_mutation_refusal():
     dirname = os.path.dirname(__file__)
     configpath = os.path.join(dirname, 'config.isofuel_single_route.json')
     config = Config.assign_config(Path(configpath))
+    config.GENETIC_RANDOM_SEED = 1
     constraint_list = basic_test_func.generate_dummy_constraint_list()
 
-    np.random.seed(1)
+    np.random.seed(config.GENETIC_RANDOM_SEED)
 
     mt = RandomPlateauMutation(config=config, constraints_list=constraint_list)
     X = get_dummy_route_input(length="short")
@@ -179,9 +181,10 @@ def test_bezier_curve_mutation(plt):
     dirname = os.path.dirname(__file__)
     configpath = os.path.join(dirname, 'config.isofuel_single_route.json')
     config = Config.assign_config(Path(configpath))
+    config.GENETIC_RANDOM_SEED = 2
     default_map = Map(32., 15, 36, 29)
     constraint_list = basic_test_func.generate_dummy_constraint_list()
-    np.random.seed(2)
+    np.random.seed(config.GENETIC_RANDOM_SEED)
 
     mt = RouteBlendMutation(config=config, constraints_list=constraint_list)
     X = get_dummy_route_input()
@@ -230,9 +233,10 @@ def test_bezier_mutation_refusal():
     dirname = os.path.dirname(__file__)
     configpath = os.path.join(dirname, 'config.isofuel_single_route.json')
     config = Config.assign_config(Path(configpath))
+    config.GENETIC_RANDOM_SEED = 1
     constraint_list = basic_test_func.generate_dummy_constraint_list()
 
-    np.random.seed(1)
+    np.random.seed(config.GENETIC_RANDOM_SEED)
 
     mt = RouteBlendMutation(config=config, constraints_list=constraint_list)
     mt.min_length = 9
@@ -268,9 +272,10 @@ def test_constraint_violation_repair(plt):
     dirname = os.path.dirname(__file__)
     configpath = os.path.join(dirname, 'config.isofuel_single_route.json')
     config = Config.assign_config(Path(configpath))
+    config.GENETIC_RANDOM_SEED = 2
     default_map = Map(32., 15, 36, 29)
     constraint_list = basic_test_func.generate_dummy_constraint_list()
-    np.random.seed(2)
+    np.random.seed(config.GENETIC_RANDOM_SEED)
 
     patchfn = PatchFactory.get_patcher(
         patch_type="isofuel_singleton",
@@ -340,12 +345,13 @@ def test_single_point_crossover(plt):
     dirname = os.path.dirname(__file__)
     configpath = os.path.join(dirname, 'config.isofuel_single_route.json')
     config = Config.assign_config(Path(configpath))
+    config.GENETIC_RANDOM_SEED = 2
     default_map = Map(32., 15, 36, 29)
     input_crs = ccrs.PlateCarree()
     constraint_list = basic_test_func.generate_dummy_constraint_list()
     departure_time = datetime(2025, 4, 1, 11, 11)
 
-    np.random.seed(2)
+    np.random.seed(config.GENETIC_RANDOM_SEED)
 
     X = get_dummy_route_input()
     old_route = copy.deepcopy(X)


### PR DESCRIPTION
…tils.py and called it where necessary to harmonize the handling of random seeds.


# Related Issue / Discussion:

Relates to issue [https://github.com/52North/WRT-Issues/issues/52]

# Changes: 

        modified:   WeatherRoutingTool/algorithms/data_utils.py
        modified:   WeatherRoutingTool/algorithms/genetic/__init__.py
        modified:   WeatherRoutingTool/algorithms/genetic/crossover.py
        modified:   WeatherRoutingTool/algorithms/genetic/mutation.py
        modified:   WeatherRoutingTool/algorithms/genetic/population.py
        modified:   WeatherRoutingTool/algorithms/genetic/utils.py
        modified:   WeatherRoutingTool/execute_routing.py *
        modified:   WeatherRoutingTool/ship/ship.py *

*access counter for weather data

# Further Details:

## Summary:

Initialized a random number generator in genetic/utils.py to harmonize the random seed and random number generation throughout the genetic algorithm. Implemented into the above listed files.

## Dependencies:

Dependencies remain unchanged.

# PR Checklist:

In the context of this PR, I:
- [x] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [x] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution

Please consider that PRs which do not meet the requirements specified in the checklist will not be evaluated. Also, PRs with no activities will be closed after a reasonable amount of time.
