### PR TITLE
fix(tests): resolve uncollected weather tests and correct assertions (#161)

### DIFF
--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from WeatherRoutingTool.weather import WeatherCond
@@ -10,15 +11,19 @@ def test_theta_from_uv(u, v, theta_res):
     assert theta_test == pytest.approx(theta_res)
 
 
-@pytest.mark.parametrize("theta,windspeed,u_res", [(45, 1, -1), (315, 1, 1), (225, 1, 1), (135, 1, -1)])
-def get_u(theta, windspeed):
+@pytest.mark.parametrize("theta,windspeed,u_res",
+                         [(45, np.sqrt(2), -1), (315, np.sqrt(2), 1),
+                          (225, np.sqrt(2), 1), (135, np.sqrt(2), -1)])
+def test_get_u(theta, windspeed, u_res):
     u_test = WeatherCond.get_u(theta, windspeed)
 
-    assert u_test == pytest.approx(u_test)
+    assert u_test == pytest.approx(u_res)
 
 
-@pytest.mark.parametrize("theta,windspeed,u_res", [(45, 1, -1), (315, 1, -1), (225, 1, 1), (135, 1, 1)])
-def get_v(theta, windspeed):
+@pytest.mark.parametrize("theta,windspeed,v_res",
+                         [(45, np.sqrt(2), -1), (315, np.sqrt(2), -1),
+                          (225, np.sqrt(2), 1), (135, np.sqrt(2), 1)])
+def test_get_v(theta, windspeed, v_res):
     v_test = WeatherCond.get_v(theta, windspeed)
 
-    assert v_test == pytest.approx(v_test)
+    assert v_test == pytest.approx(v_res)


### PR DESCRIPTION
# Related Issue / Discussion:

Fixes Issue #161

# Changes: 
Please list the central functionalities that have been changed:

- **Modified** `tests/test_weather.py`

# Further Details:

## Summary:

- **Motivation**: The test infrastructure for the `WeatherCond` class (`get_u()` and `get_v()` methods) was completely broken and omitted during test collection.
- **Before**: 
  - Test functions lacked the `test_` prefix, preventing `pytest` from discovering them.
  - Parameter counts in `@pytest.mark.parametrize` did not match the function signatures.
  - Assertions were self-referential (e.g., checking if a variable equaled itself) or mathematically incorrect regarding the inverse logic for `test_theta_from_uv`.
- **After**: 
  - Renamed functions to follow proper `test_` prefixes.
  - Aligned function signatures with the parametrized decorators (`u_res` / `v_res`).
  - Implemented proper value checks utilizing `pytest.approx()` and updated the test data (`windspeed = np.sqrt(2)`) to ensure mathematical accuracy. Total active passing tests in this file increased from 4 to 12.

## Dependencies:

No new dependencies are required for this modification.

# PR Checklist:

In the context of this PR, I:
- [ ] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [ ] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution