### PR TITLE
fix (ship): clamp arcsin argument to [-1, 1] with np.clip to prevent NaN

### DIFF
--- a/WeatherRoutingTool/ship/direct_power_boat.py
+++ b/WeatherRoutingTool/ship/direct_power_boat.py
@@ -230,12 +230,9 @@ class DirectPowerBoat(Boat):
             arg_arcsin = true_wind_speed[iang] * np.sin(np.radians(true_wind_angle[iang])) / apparent_wind_speed[
                 iang] * u.radian
 
-            # catch it if argument of arcsin is > 1 due to rounding issues but make sure to apply this only for
-            # rounding issues
-            diff_to_one = arg_arcsin - 1 * u.radian
-            if diff_to_one > 0:
-                assert diff_to_one < 0.000001 * u.radian
-                arg_arcsin = 1 * u.radian
+            # clamp the arcsin argument into its valid domain [-1, 1] to guard against
+            # floating-point rounding errors that would otherwise make np.arcsin return NaN
+            arg_arcsin = np.clip(arg_arcsin, -1 * u.radian, 1 * u.radian)
 
             if apparent_wind_speed[iang] > 0:
                 apparent_wind_angle[iang] = np.arcsin(arg_arcsin.value) * u.radian


### PR DESCRIPTION
Floating-point rounding could push arg_arcsin in get_apparent_wind slightly outside the valid domain of np.arcsin. The previous manual check only clamped the upper bound, so values marginally below -1 produced silent NaNs that corrupted apparent wind angles and downstream fuel/route metrics. Replace the one-sided check with a two-sided np.clip.

Fixes #170

# Related Issue / Discussion:
Fixes Issue #170

# Changes: 
- **Modified** `WeatherRoutingTool/ship/direct_power_boat.py` — Replaced the manual one-sided upper bound check for `arg_arcsin` inside `get_apparent_wind()` with a robust two-sided `np.clip`.

# Further Details:

## Summary:
* **Motivation & Context:** In `get_apparent_wind()`, floating-point rounding errors occasionally pushed the argument for `np.arcsin()` slightly outside the strict math domain of [-1, 1]. While an existing manual check handled the upper threshold, values slightly falling below -1 bypassed it, generating silent `NaN` values that cascaded down into critical ship routing and fuel consumption metrics.
* **Before:** The code evaluated a manual difference condition (`diff_to_one`) that only protected against exceeding the upper bound of 1.0.
* **After:** Replaced with `np.clip(arg_arcsin, -1 * u.radian, 1 * u.radian)`, ensuring absolute two-sided domain safety while cleanly preserving the `astropy.units` Quantity wrapper.

## Dependencies:
* No new dependencies are required for this modification.

# PR Checklist:
- [ ] have (already previously) filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and received positive feedback on this matter
- [x] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution