### PR TITLE
fix(cli): apply warning filter prior to execute_routing and add test coverage

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,7 +6,7 @@ from WeatherRoutingTool.execute_routing import execute_routing
 from WeatherRoutingTool.ship.ship_config import ShipConfig
 
 
-if __name__ == "__main__":
+def main(args_list=None):
     parser = argparse.ArgumentParser(description='Weather Routing Tool')
     parser.add_argument('-f', '--file', help="Config file name (absolute path)", required=True, type=str)
     parser.add_argument('--warnings-log-file',
@@ -17,7 +17,7 @@ if __name__ == "__main__":
                         required=False, type=str, default='False')
     parser.add_argument('--filter-warnings', help="Filter action. <default|error|ignore|always|module|once>."
                         "Defaults to 'default'.", required=False, type=str, default='default')
-    args = parser.parse_args()
+    args = parser.parse_args(args_list)
     if not args.file:
         raise RuntimeError("No config file name provided!")
     debug_str = str(args.debug).lower()
@@ -30,6 +30,9 @@ if __name__ == "__main__":
     if args.filter_warnings not in ['default', 'error', 'ignore', 'always', 'module', 'once']:
         raise ValueError("--filter-warnings has to be one of <default|error|ignore|always|module|once>")
 
+    # set warning filter action (https://docs.python.org/3/library/warnings.html)
+    warnings.filterwarnings(args.filter_warnings)
+
     ##
     # initialise logging
     set_up_logging(args.info_log_file, args.warnings_log_file, args.debug)
@@ -39,5 +42,6 @@ if __name__ == "__main__":
     ship_config = ShipConfig.assign_config(args.file)
     execute_routing(config, ship_config)
 
-    # set warning filter action (https://docs.python.org/3/library/warnings.html)
-    warnings.filterwarnings(args.filter_warnings)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import pytest
+from cli import main
+
+
+class TestCLI(unittest.TestCase):
+
+    @patch('cli.execute_routing')
+    @patch('cli.ShipConfig.assign_config')
+    @patch('cli.Config.assign_config')
+    @patch('cli.set_up_logging')
+    @patch('cli.warnings.filterwarnings')
+    def test_cli_main_valid_args(self, mock_filterwarnings, mock_logging, mock_config, mock_ship_config, mock_execute):
+        mock_config.return_value = MagicMock()
+        mock_ship_config.return_value = MagicMock()
+
+        args = ['-f', 'config.json', '--debug', 'true', '--filter-warnings', 'ignore']
+        main(args)
+
+        mock_filterwarnings.assert_called_once_with('ignore')
+        mock_logging.assert_called_once_with(None, None, True)
+        mock_config.assert_called_once_with('config.json')
+        mock_ship_config.assert_called_once_with('config.json')
+        mock_execute.assert_called_once_with(mock_config.return_value, mock_ship_config.return_value)
+
+    @patch('cli.execute_routing')
+    @patch('cli.ShipConfig.assign_config')
+    @patch('cli.Config.assign_config')
+    @patch('cli.set_up_logging')
+    @patch('cli.warnings.filterwarnings')
+    def test_cli_warning_filter_applied_before_routing(
+            self, mock_filterwarnings, mock_logging, mock_config, mock_ship_config, mock_execute):
+        manager = MagicMock()
+        manager.attach_mock(mock_filterwarnings, 'filterwarnings')
+        manager.attach_mock(mock_execute, 'execute_routing')
+
+        args = ['-f', 'config.json', '--filter-warnings', 'always']
+        main(args)
+
+        expected_calls = [
+            call.filterwarnings('always'),
+            call.execute_routing(mock_config.return_value, mock_ship_config.return_value)
+        ]
+        self.assertEqual(manager.mock_calls, expected_calls)
+
+    def test_cli_invalid_debug_raises_value_error(self):
+        args = ['-f', 'config.json', '--debug', 'invalid_bool']
+        with pytest.raises(ValueError, match="--debug does not have a valid value"):
+            main(args)
+
+    def test_cli_invalid_filter_warnings_raises_value_error(self):
+        args = ['-f', 'config.json', '--filter-warnings', 'invalid_action']
+        with pytest.raises(ValueError, match="--filter-warnings has to be one of"):
+            main(args)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Related Issue / Discussion:
Fixes Issue #205

# Changes: 
- **Modified**: `cli.py` — Refactored CLI logic into a testable `main(args_list=None)` function and moved `warnings.filterwarnings()` prior to `execute_routing()`.
- **New**: `tests/test_cli.py` — Added unit tests for CLI argument parsing, debug boolean handling, and call order assertions.

# Further Details:

## Summary:
* **Motivation & Context**: Currently, `warnings.filterwarnings(args.filter_warnings)` in `cli.py` is invoked after `execute_routing()` has already run. Consequently, any warnings issued during dataset loading or optimization bypass the specified filter setting.
* **Before**: Warning filter configuration occurred on the last line of `cli.py` after route execution finished.
* **After**: Warning filter configuration is executed immediately after argument parsing, prior to logging initialization and route optimization.

## Dependencies:
No new external dependencies required.

# PR Checklist:

In the context of this PR, I:
- [x] have filled the [52North Contributor License Agreement](https://52north.org/software/licensing/cla-guidelines/) and am waiting for feedback
- [x] provide unit tests embedded in the WRT test framework (WeatherRoutingTool/tests) that allow the simple testing of the new/modified functionalities. All (previous and new) unit tests execute without new error messages.
- [x] ensure that the [code formatter](https://github.com/52North/WeatherRoutingTool/blob/main/flake8.sh) runs without errors/warnings
- [x] ensure that my changes follow the [WRT’s guidelines for contributing](https://52north.github.io/WeatherRoutingTool/source/contributing.html) at the time of the contribution
